### PR TITLE
Recompute requirement every rendering

### DIFF
--- a/src/Requirement/Requirement.js
+++ b/src/Requirement/Requirement.js
@@ -10,7 +10,6 @@ class RequirementComponent extends React.Component {
 
     this.CLASS_NAME = 'attributeRequirement';
 
-    this.setRequirement();
   }
 
   setRequirement() {
@@ -33,6 +32,9 @@ class RequirementComponent extends React.Component {
   }
 
   render() {
+
+    this.setRequirement();
+
     return (
       <div className={this.getClassName()}>
         <span className="attributeRequirementIcon"></span>


### PR DESCRIPTION
If leaving that function call in the constructor, we are not able to pick up the right class name when the component is rendered again due to a prop change (that can be the requirement itself).
### What are you talking about?

Look at the required circle. (Click on the image to enlarge)
#### Master

![without](https://cloud.githubusercontent.com/assets/1416224/9762784/034f3d90-5706-11e5-984a-35bd7ca50178.gif)
#### PR

![with](https://cloud.githubusercontent.com/assets/1416224/9762791/07f643f2-5706-11e5-8472-18b3d9d065ee.gif)
