### PR TITLE
Playground redesign, layout, colors

### DIFF
--- a/playground/components/Playground.js
+++ b/playground/components/Playground.js
@@ -33,17 +33,33 @@ class Playground extends React.Component {
   render() {
     return (
       <div className="playgrund-app">
-        <div className="column">
-          <EditorComponent />
-        </div>
+        <header className="playground-header">
+          <a href="/" className="logo">Attributes Kit Playground</a>
+          <ul className="docs-links">
+            <li><a href="https://github.com/apiaryio/attributes-kit" target="_blank" className="attributes-kit-repo">Attributes Kit Repository</a></li>
+            <li><a href="https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md" target="_blank" className="mson-doc">MSON Specification</a></li>
+          </ul>
+        </header>
+        <div className="playground-columns">
+          <div className="column editor-column">
+            <ul className="column-controls">
+              <li><a href="">Copy</a></li>
+            </ul>
+            <EditorComponent />
+          </div>
 
-        <div className="column">
-          <JsonFormatterComponent element={this.state.attributes} />
-        </div>
-
-        <div className="column">
-          <AttributesKit.Attributes element={this.state.attributes} />
-        </div>
+          <div className="column result-column">
+            <ul className="column-controls">
+              <li><a href="">Show Refract</a></li>
+            </ul>
+            <div className="tab">
+              <JsonFormatterComponent element={this.state.attributes} />
+            </div>
+            <div className="tab active">
+              <AttributesKit.Attributes element={this.state.attributes} />
+            </div>
+          </div>
+          </div>
       </div>
     );
   }

--- a/playground/styles/layout.styl
+++ b/playground/styles/layout.styl
@@ -1,3 +1,15 @@
+clearfix()
+  zoom 1
+  &:after
+  &:before
+    content ""
+    display table
+  &:after
+    clear both
+
+text-color = #8A93A3
+link-hover = #9999CC
+
 *
   -moz-box-sizing border-box
   -webkit-box-sizing border-box
@@ -6,18 +18,144 @@
   margin 0
   padding 0
 
+body
+  -webkit-font-smoothing antialiased
+  position relative
+
+body,
+html,
+#playgroundContainer
+  height 100%
+
+.playground-header
+  font-size 16px
+  background #FFFFFF
+  box-shadow 0px 2px 14px 0px rgba(51,67,88,0.10)
+  position relative
+  z-index 2
+  clearfix()
+
+.logo
+  display block
+  color text-color
+  text-decoration none
+  text-transform uppercase
+  font-family 'Source Code Pro'
+  font-weight 400
+  font-size .625rem
+  letter-spacing .125rem
+  line-height 50px
+  padding 0 20px
+
+  &:hover
+    color darken(text-color, 30%)
+
+.docs-links
+  li
+    display inline-block
+  a
+    display block
+    color text-color
+    text-decoration none
+    text-transform uppercase
+    font-family 'Source Sans Pro', sans-serif
+    font-weight bold
+    font-size .625rem
+    letter-spacing .0625rem
+    line-height 50px
+    padding 0 20px
+
+    &:hover
+      color link-hover
+
 .visualTestingContainer
   display flex
   flex-wrap wrap
   justify-content space-between
 
-.column
-  float: left
-  width 30%
-  padding 10px
-
+.playgrund-app
+  width 100%
+  height 100%
 
 .column
+  position relative
+  min-height 300px
+
   textarea
+    position absolute
+    left 0
+    right 0
+    top 50px
+    bottom 0
+    outline none
+    background transparent
+    border 0
+    padding 30px
+    font-family 'Source Code Pro'
+    font-weight 300
+    font-size .8125rem
+    color #24272E
+    line-height 1.5rem
     width 100%
-    min-height 200px
+
+    &:hover
+    &:focus
+      outline none
+
+.editor-column
+  padding 30px
+  padding-left: 0
+  background #F4F6F9
+  font-size 16px
+
+.result-column
+  padding 30px
+
+.tab
+  display none
+
+  &.active
+    display block
+
+.column-controls
+  text-align right
+  list-style none
+  padding 0
+  margin 0
+
+  li
+    display inline-block
+
+    a
+      font-weight 600
+      opacity 0.5
+      font-family 'Source Sans Pro', sans-serif
+      font-size .7125rem
+      color text-color
+      letter-spacing .0625rem
+      text-transform uppercase
+      text-decoration none
+      cursor pointer
+
+      &:hover
+        opacity 1
+
+@media all and (min-width 800px)
+  .playground-columns
+    display flex
+    flex-direction row
+    flex 1
+
+  .playgrund-app
+    display flex
+    flex-direction column
+
+  .column
+    flex 1
+
+  .playground-header
+    .logo
+      float left
+
+    .docs-links
+      float right

--- a/src/Attributes/Attributes.js
+++ b/src/Attributes/Attributes.js
@@ -16,10 +16,6 @@ class Attributes extends React.Component {
     return (
       <div>
         <div>
-          <h1>Attributes</h1>
-        </div>
-
-        <div>
           <Attribute
             element={this.props.element}
             theme={this.props.theme}


### PR DESCRIPTION
This PR is for visual redesign of the Playground based on mockups:

### Empty state
![empty state 2x](https://cloud.githubusercontent.com/assets/1576931/11121895/bd443e24-8958-11e5-9478-070054412e8e.png)

### Full state
![full state 2x](https://cloud.githubusercontent.com/assets/1576931/11121896/bd449324-8958-11e5-8bd9-2b3df6cdfe70.png)


### Details
1. Two column layout
2. Header added
3. Links to MSON documentations and Attributes kit repository
4. Added tools for copy MSON and Show Refract

### Not working
1. Copy to clipboard
2. Show refract switch
