### PR TITLE
Replace the ugly run.js script in favor of babel-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,22 +31,22 @@
   "main": "dist/attributes-kit",
   "scripts": {
     "build": "npm run build:server && npm run build:client",
-    "build:server": "node ./scripts/run.js ./serverBuild",
+    "build:server": "babel-node ./scripts/serverBuild",
     "build:client": "npm run build:client:full && npm run build:client:noDep && npm run build:client:react && NODE_ENV=production npm run build:client:full",
-    "build:client:react": "node ./scripts/run.js ./clientBuild",
-    "build:client:full": "node ./scripts/run.js ./clientBuild full",
-    "build:client:noDep": "node ./scripts/run.js ./clientBuild noDep",
-    "generate-fixtures": "npm run build:server && node ./scripts/run.js ./generateFixtures",
+    "build:client:react": "babel-node ./scripts/clientBuild",
+    "build:client:full": "babel-node ./scripts/clientBuild full",
+    "build:client:noDep": "babel-node ./scripts/clientBuild noDep",
+    "generate-fixtures": "npm run build:server && babel-node ./scripts/generateFixtures",
     "lint": "eslint src playground",
-    "playground": "shell-exec 'npm run start' 'node ./scripts/run.js ./launchBrowser http://localhost:8080/'",
+    "playground": "shell-exec 'npm run start' 'babel-node ./scripts/launchBrowser http://localhost:8080/'",
     "prepublish": "not-in-install && npm run build || :",
-    "start": "node ./scripts/run.js ./devServer",
+    "start": "babel-node ./scripts/devServer",
     "test:unit": "mocha --compilers js:babel-core/register ./src/**/test/*.js --recursive",
     "test:unit:watch": "mocha -w --compilers js:babel-core/register ./src/**/test/*.js --recursive",
     "test:examples": "npm run build:server && mocha --compilers js:babel-core/register ./test/**.js --recursive",
     "test:functional": "echo 'We don't have functional tests yet",
     "test": "npm run lint && npm run test:unit && npm run test:examples && npm run test:functional",
-    "examples": "NODE_ENV=test shell-exec 'npm run start' 'node ./scripts/run.js ./launchBrowser http://localhost:8080/examples'"
+    "examples": "NODE_ENV=test shell-exec 'npm run start' 'babel-node ./scripts/launchBrowser http://localhost:8080/examples'"
   },
   "repository": {
     "type": "git",
@@ -60,6 +60,7 @@
   "homepage": "https://github.com/apiaryio/attributes-kit#readme",
   "devDependencies": {
     "async": "^1.4.2",
+    "babel": "^5.8.34",
     "babel-core": "^5.8.33",
     "babel-eslint": "^4.1.3",
     "babel-loader": "^5.3.2",

--- a/scripts/run.js
+++ b/scripts/run.js
@@ -1,2 +1,0 @@
-require('babel-core/register');
-require(process.argv[2]);

--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -40,7 +40,7 @@ export default {
         test: /\.js[x]?$/,
         exclude: /node_modules/,
         loaders: (function() {
-          const loaders = ['babel-loader?stage=0'];
+          const loaders = ['babel-loader'];
           if (!isProduction) {
             loaders.unshift('react-hot');
           }


### PR DESCRIPTION
Thanks to `babel-node` command line utility, we can get rid of `run.js` script. The main reason for that is it respects things into `.babelrc`

With this, the only blocking thing to migrate to babel6 ( #141 ) is `babel-eslint`