### PR TITLE
Enable client side parsing with drafter.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "classnames": "^2.1.5",
     "css-loader": "^0.21.0",
     "dedent": "^0.6.0",
+    "drafter.js": "^2.0.0-pre.1",
     "eslint": "^1.5.0",
     "eslint-config-airbnb": "^0.1.0",
     "eslint-plugin-react": "^3.5.1",

--- a/playground/actions/editor.js
+++ b/playground/actions/editor.js
@@ -2,19 +2,36 @@ import request from 'superagent';
 
 import dispatcher from '../dispatcher';
 import types from './types';
+import drafter from 'drafter.js';
 
 export default {
-  parse(source) {
-    request
-      .post('/parse')
-      .send({source})
-      .set('Accept', 'application/json')
-      .end((err, res) => {
+  parse(source, clientSideParsing) {
+    if (clientSideParsing === false) {
+      request
+        .post('/parse')
+        .send({source})
+        .set('Accept', 'application/json')
+        .end((err, res) => {
+          dispatcher.dispatch({
+            type: types.MSON_PARSED,
+            attributes: res.body.attributes,
+            errors: res.body.errors,
+          });
+        });
+    } else {
+      let attributes = '';
+      let errors = '';
+      try {
+        attributes = drafter.parse(source);
+      } catch (e) {
+        errors = e.toString();
+      } finally {
         dispatcher.dispatch({
           type: types.MSON_PARSED,
-          attributes: res.body.attributes,
-          errors: res.body.errors,
+          attributes: attributes,
+          errors: errors,
         });
-      });
+      }
+    }
   },
 };

--- a/playground/actions/editor.js
+++ b/playground/actions/editor.js
@@ -2,7 +2,6 @@ import request from 'superagent';
 
 import dispatcher from '../dispatcher';
 import types from './types';
-import drafter from 'drafter.js';
 
 export default {
   parse(source, clientSideParsing) {
@@ -18,13 +17,23 @@ export default {
             errors: res.body.errors,
           });
         });
-    } else {
-      let attributes = '';
+    } else if (drafter !== undefined) {
+      let attributes = {};
       let errors = '';
       try {
-        attributes = drafter.parse(source);
+        const result = drafter.parse(source);
+        const categories = result.content[0];
+        if (categories.content[0]) {
+          const category = categories.content[0];
+          if (category.content[0]) {
+            const resource = category.content[0];
+            if (resource.content[0]) {
+              attributes = resource.content[0];
+            }
+          }
+        }
       } catch (e) {
-        errors = e.toString();
+        errors = e.message;
       } finally {
         dispatcher.dispatch({
           type: types.MSON_PARSED,

--- a/playground/components/Editor.js
+++ b/playground/components/Editor.js
@@ -19,7 +19,7 @@ class EditorComponent extends React.Component {
     super();
 
     this.state = {
-      clientSideParsing: true,
+      clientSideParsing: false,
       msonCode: dedent`
 
       # Data Structures
@@ -60,7 +60,10 @@ class EditorComponent extends React.Component {
       annotations = this.props.errors.map(this.generateAnnotation);
     } else if (lodash.isObject(this.props.errors)) {
       annotations.push(this.generateAnnotation(this.props.errors));
+    } else if (typeof(this.props.error) === 'string') {
+      annotations.push({type: 'error', text: this.props.errors, row: 0});
     }
+
 
     if (lodash.isEmpty(annotations)) {
       session.clearAnnotations();
@@ -90,8 +93,10 @@ class EditorComponent extends React.Component {
     };
   }
 
-  clientSide = () => {
-    this.setState({clientSideParsing: true});
+  handleSwitchParserType = () => {
+    this.setState((state) => {
+      return {clientSideParsing: !state.clientSideParsing};
+    });
   }
 
   handleChange = (msonCode) => {
@@ -102,7 +107,6 @@ class EditorComponent extends React.Component {
   render() {
     return (
       <div>
-        <button onClick={this.clientSide}>Client Side parsing</button>
         <AceEditor
           onLoad={this.onLoad}
           heigth="500px"
@@ -115,6 +119,11 @@ class EditorComponent extends React.Component {
           tabSize={2}
           editorProps={{$blockScrolling: true}}
         />
+
+        <button onClick={this.handleSwitchParserType}>
+          {'Switch to ' + (this.state.clientSideParsing ? 'drafter' : 'drafter.js')}
+        </button>
+
       </div>
     );
   }

--- a/playground/components/Editor.js
+++ b/playground/components/Editor.js
@@ -19,6 +19,7 @@ class EditorComponent extends React.Component {
     super();
 
     this.state = {
+      clientSideParsing: true,
       msonCode: dedent`
 
       # Data Structures
@@ -44,7 +45,7 @@ class EditorComponent extends React.Component {
   }
 
   componentDidMount() {
-    EditorActions.parse(this.state.msonCode);
+    EditorActions.parse(this.state.msonCode, this.state.clientSideParsing);
   }
 
   onLoad = (aceEditor) => {
@@ -89,25 +90,32 @@ class EditorComponent extends React.Component {
     };
   }
 
+  clientSide = () => {
+    this.setState({clientSideParsing: true});
+  }
+
   handleChange = (msonCode) => {
     this.setState({msonCode});
-    EditorActions.parse(msonCode);
+    EditorActions.parse(msonCode, this.state.clientSideParsing);
   };
 
   render() {
     return (
-      <AceEditor
-        onLoad={this.onLoad}
-        heigth="500px"
-        width="100%"
-        theme="github"
-        mode="markdown"
-        onChange={this.handleChange}
-        name="msonEditor"
-        value={this.state.msonCode}
-        tabSize={2}
-        editorProps={{$blockScrolling: true}}
-      />
+      <div>
+        <button onClick={this.clientSide}>Client Side parsing</button>
+        <AceEditor
+          onLoad={this.onLoad}
+          heigth="500px"
+          width="100%"
+          theme="github"
+          mode="markdown"
+          onChange={this.handleChange}
+          name="msonEditor"
+          value={this.state.msonCode}
+          tabSize={2}
+          editorProps={{$blockScrolling: true}}
+        />
+      </div>
     );
   }
 }

--- a/playground/views/index.html
+++ b/playground/views/index.html
@@ -11,6 +11,7 @@
 
   <script src="/webpack-dev-server.js"></script>
   <script src="/playground.js"></script>
+  <script src="https://npmcdn.com/drafter.js"></script>
 
   <script type="text/javascript">
     WebFontConfig = {


### PR DESCRIPTION
This PR is a starting point to have a full client side parsing using `drafter.js`

1. `drafter.js` is super slow compared to its C++ counter part. The experience is not the best one. This should be moved to a webworker or the UI will hang (totally)
2. We can't use its npm package given that emscripten has a limitation which I'm actively tracking: https://github.com/kripken/emscripten/issues/2415#issuecomment-158005938