### PR TITLE
Update React Hot Loader to the latest version to support getters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attributes-kit",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "React component for MSON rendering",
   "engines": {
     "node": "0.12"

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "protagonist": "1.2.5",
     "react-ace": "^2.6.0",
     "react-dom": "0.14.3",
-    "react-hot-loader": "^1.3.0",
+    "react-hot-loader": "^2.0.0-alpha-4",
     "react-router": "1.0.1",
     "react": "0.14.3",
     "shell-executor": "^0.3.2",


### PR DESCRIPTION
This fixes the `Uncaught TypeError: Cannot read property 'theme' of undefined` error when using Playground (`npm start`).