### PR TITLE
Support primitive types rendering

### DIFF
--- a/fixtures/array-fixed-inline-samples.md
+++ b/fixtures/array-fixed-inline-samples.md
@@ -13,112 +13,67 @@
                 </div>
                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                     <div style="width:100%;height:auto;">
-                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:none;padding-top:8px;padding-bottom:8px;">
+                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
+                            <div style="height:auto;width:120px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:120px;min-width:120px;">
+                                <div style="float:left;width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:16px;color:#4C5264;line-height:18px;">street</div>
+                            </div>
+                            <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
+                                <div style="float:left;width:100%;height:auto;">
+                                    <div class="attributeTooltip" style="display:none;"><span class="attributeTooltipText">optional</span></div>
+                                </div>
+                            </div>
                             <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                    <div style="height:auto;width:20px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:20px;min-width:20px;">
-                                        <div style="width:100%;height:auto;">
-                                            <div style="width:100%;height:20px;background-repeat:no-repeat;background-position:left center;background-image:url([object Object]);background-size:12px 7px;"></div>
-                                        </div>
-                                    </div>
-                                    <div style="height:auto;width:100px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:100px;min-width:100px;">
-                                        <div style="float:left;width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:16px;color:#4C5264;line-height:18px;">address</div>
-                                    </div>
-                                    <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
-                                        <div style="float:left;width:100%;height:auto;">
-                                            <div class="attributeTooltip" style="display:none;"><span class="attributeTooltipText">fixed</span></div>
-                                        </div>
-                                    </div>
-                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
-                                        <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:14px;color:#8A93A3;">array</div>
-                                    </div>
-                                </div>
-                                <div style="width:100%;height:auto;padding-left:13px;border-left:1px solid #E8EBEE;margin-left:6px;padding-bottom:0px;">
-                                    <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                    <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;margin-top:8px;">
-                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
-                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border:1px solid #E8EBEE;border-bottom:none;padding-bottom:6px;padding-left:8px;padding-top:4px;background-color:#F8F8F9;">
-                                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:center;align-items:flex-start;">
-                                                        <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:12px;color:#8A93A3;">array</div>
-                                                    </div>
-                                                </div>
-                                                <div style="width:100%;height:auto;border:1px solid #E8EBEE;">
-                                                    <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;"><span style="position:absolute;top:8px;right:8px;font-family:Source Code Pro;font-size:14px;color:#C8CDD4;line-height:18px;">0</span>
-                                                        <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:8px;">
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                                                <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:14px;color:#8A93A3;margin-bottom:4px;">string</div>
-                                                            </div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;margin-top:2px;">
-                                                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
-                                                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;margin-top:6px;">
-                                                                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
-                                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;cursor:pointer;">
-                                                                                    <div style="height:auto;width:12px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:12px;max-width:12px;">
-                                                                                        <div style="width:12px;height:12px;background-repeat:no-repeat;background-position:left center;background-image:url([object Object]);background-size:7px 12px;"></div>
-                                                                                    </div>
-                                                                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
-                                                                                        <div style="line-height:12px;letter-spacing:0.85px;font-family:Source Sans Pro;font-size:12px;color:#A3A7B2;text-transform:uppercase;padding-left:6px;">Sample</div>
-                                                                                    </div>
-                                                                                </div>
-                                                                            </div>
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                                        </div>
-                                                    </div>
-                                                    <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;"><span style="position:absolute;top:8px;right:8px;font-family:Source Code Pro;font-size:14px;color:#C8CDD4;line-height:18px;">1</span>
-                                                        <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:8px;">
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                                                <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:14px;color:#8A93A3;margin-bottom:4px;">string</div>
-                                                            </div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                                                <div style="float:left;width:auto;height:auto;margin:0px;padding:0px;font-weight:600;background-color:#f0f1f4;border-radius:4px;padding-top:2px;padding-bottom:2px;padding-left:4px;padding-right:4px;font-family:Source Sans Pro;font-size:15px;color:#4C5264;line-height:19px;">city</div>
-                                                            </div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                                        </div>
-                                                    </div>
-                                                    <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:none;padding-top:8px;padding-bottom:8px;"><span style="position:absolute;top:8px;right:8px;font-family:Source Code Pro;font-size:14px;color:#C8CDD4;line-height:18px;">2</span>
-                                                        <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:8px;">
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                                                <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:14px;color:#8A93A3;margin-bottom:4px;">string</div>
-                                                            </div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;margin-top:2px;">
-                                                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
-                                                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;margin-top:6px;">
-                                                                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
-                                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;cursor:pointer;">
-                                                                                    <div style="height:auto;width:12px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:12px;max-width:12px;">
-                                                                                        <div style="width:12px;height:12px;background-repeat:no-repeat;background-position:left center;background-image:url([object Object]);background-size:7px 12px;"></div>
-                                                                                    </div>
-                                                                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
-                                                                                        <div style="line-height:12px;letter-spacing:0.85px;font-family:Source Sans Pro;font-size:12px;color:#A3A7B2;text-transform:uppercase;padding-left:6px;">Sample</div>
-                                                                                    </div>
-                                                                                </div>
-                                                                            </div>
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
+                                    <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:14px;color:#8A93A3;margin-bottom:4px;">string</div>
                                 </div>
                                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                    <div></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
+                            <div style="height:auto;width:120px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:120px;min-width:120px;">
+                                <div style="float:left;width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:16px;color:#4C5264;line-height:18px;">city</div>
+                            </div>
+                            <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
+                                <div style="float:left;width:100%;height:auto;">
+                                    <div class="attributeTooltip" style="display:none;"><span class="attributeTooltipText">optional</span></div>
+                                </div>
+                            </div>
+                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                    <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:14px;color:#8A93A3;margin-bottom:4px;">string</div>
+                                </div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                    <div></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
+                            <div style="height:auto;width:120px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:120px;min-width:120px;">
+                                <div style="float:left;width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:16px;color:#4C5264;line-height:18px;">state</div>
+                            </div>
+                            <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
+                                <div style="float:left;width:100%;height:auto;">
+                                    <div class="attributeTooltip" style="display:none;"><span class="attributeTooltipText">optional</span></div>
+                                </div>
+                            </div>
+                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                    <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:14px;color:#8A93A3;margin-bottom:4px;">string</div>
+                                </div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                    <div></div>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/fixtures/array-fixed-inline.md
+++ b/fixtures/array-fixed-inline.md
@@ -13,82 +13,67 @@
                 </div>
                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                     <div style="width:100%;height:auto;">
-                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:none;padding-top:8px;padding-bottom:8px;">
+                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
+                            <div style="height:auto;width:120px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:120px;min-width:120px;">
+                                <div style="float:left;width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:16px;color:#4C5264;line-height:18px;">street</div>
+                            </div>
+                            <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
+                                <div style="float:left;width:100%;height:auto;">
+                                    <div class="attributeTooltip" style="display:none;"><span class="attributeTooltipText">optional</span></div>
+                                </div>
+                            </div>
                             <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                    <div style="height:auto;width:20px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:20px;min-width:20px;">
-                                        <div style="width:100%;height:auto;">
-                                            <div style="width:100%;height:20px;background-repeat:no-repeat;background-position:left center;background-image:url([object Object]);background-size:12px 7px;"></div>
-                                        </div>
-                                    </div>
-                                    <div style="height:auto;width:100px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:100px;min-width:100px;">
-                                        <div style="float:left;width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:16px;color:#4C5264;line-height:18px;">address</div>
-                                    </div>
-                                    <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
-                                        <div style="float:left;width:100%;height:auto;">
-                                            <div class="attributeTooltip" style="display:none;"><span class="attributeTooltipText">fixed</span></div>
-                                        </div>
-                                    </div>
-                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
-                                        <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:14px;color:#8A93A3;">array</div>
-                                    </div>
-                                </div>
-                                <div style="width:100%;height:auto;padding-left:13px;border-left:1px solid #E8EBEE;margin-left:6px;padding-bottom:0px;">
-                                    <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                    <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;margin-top:8px;">
-                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
-                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border:1px solid #E8EBEE;border-bottom:none;padding-bottom:6px;padding-left:8px;padding-top:4px;background-color:#F8F8F9;">
-                                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:center;align-items:flex-start;">
-                                                        <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:12px;color:#8A93A3;">array</div>
-                                                    </div>
-                                                </div>
-                                                <div style="width:100%;height:auto;border:1px solid #E8EBEE;">
-                                                    <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;"><span style="position:absolute;top:8px;right:8px;font-family:Source Code Pro;font-size:14px;color:#C8CDD4;line-height:18px;">0</span>
-                                                        <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:8px;">
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                                                <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:14px;color:#8A93A3;margin-bottom:4px;">string</div>
-                                                            </div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                                                <div style="float:left;width:auto;height:auto;margin:0px;padding:0px;font-weight:600;background-color:#f0f1f4;border-radius:4px;padding-top:2px;padding-bottom:2px;padding-left:4px;padding-right:4px;font-family:Source Sans Pro;font-size:15px;color:#4C5264;line-height:19px;">street</div>
-                                                            </div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                                        </div>
-                                                    </div>
-                                                    <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;"><span style="position:absolute;top:8px;right:8px;font-family:Source Code Pro;font-size:14px;color:#C8CDD4;line-height:18px;">1</span>
-                                                        <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:8px;">
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                                                <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:14px;color:#8A93A3;margin-bottom:4px;">string</div>
-                                                            </div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                                                <div style="float:left;width:auto;height:auto;margin:0px;padding:0px;font-weight:600;background-color:#f0f1f4;border-radius:4px;padding-top:2px;padding-bottom:2px;padding-left:4px;padding-right:4px;font-family:Source Sans Pro;font-size:15px;color:#4C5264;line-height:19px;">city</div>
-                                                            </div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                                        </div>
-                                                    </div>
-                                                    <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:none;padding-top:8px;padding-bottom:8px;"><span style="position:absolute;top:8px;right:8px;font-family:Source Code Pro;font-size:14px;color:#C8CDD4;line-height:18px;">2</span>
-                                                        <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:8px;">
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                                                <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:14px;color:#8A93A3;margin-bottom:4px;">string</div>
-                                                            </div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                                                <div style="float:left;width:auto;height:auto;margin:0px;padding:0px;font-weight:600;background-color:#f0f1f4;border-radius:4px;padding-top:2px;padding-bottom:2px;padding-left:4px;padding-right:4px;font-family:Source Sans Pro;font-size:15px;color:#4C5264;line-height:19px;">state</div>
-                                                            </div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
+                                    <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:14px;color:#8A93A3;margin-bottom:4px;">string</div>
                                 </div>
                                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                    <div></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
+                            <div style="height:auto;width:120px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:120px;min-width:120px;">
+                                <div style="float:left;width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:16px;color:#4C5264;line-height:18px;">city</div>
+                            </div>
+                            <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
+                                <div style="float:left;width:100%;height:auto;">
+                                    <div class="attributeTooltip" style="display:none;"><span class="attributeTooltipText">optional</span></div>
+                                </div>
+                            </div>
+                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                    <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:14px;color:#8A93A3;margin-bottom:4px;">string</div>
+                                </div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                    <div></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
+                            <div style="height:auto;width:120px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:120px;min-width:120px;">
+                                <div style="float:left;width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:16px;color:#4C5264;line-height:18px;">state</div>
+                            </div>
+                            <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
+                                <div style="float:left;width:100%;height:auto;">
+                                    <div class="attributeTooltip" style="display:none;"><span class="attributeTooltipText">optional</span></div>
+                                </div>
+                            </div>
+                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                    <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:14px;color:#8A93A3;margin-bottom:4px;">string</div>
+                                </div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
+                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                    <div></div>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/fixtures/boolean.md
+++ b/fixtures/boolean.md
@@ -11,31 +11,7 @@
                         </div>
                     </div>
                 </div>
-                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                    <div style="width:100%;height:auto;">
-                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                            <div style="height:auto;width:120px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:120px;min-width:120px;">
-                                <div style="float:left;width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:16px;color:#4C5264;line-height:18px;">street</div>
-                            </div>
-                            <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
-                                <div style="float:left;width:100%;height:auto;">
-                                    <div class="attributeTooltip" style="display:none;"><span class="attributeTooltipText">optional</span></div>
-                                </div>
-                            </div>
-                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
-                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                    <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:14px;color:#8A93A3;margin-bottom:4px;">boolean</div>
-                                </div>
-                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                    <div></div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
             </div>
         </div>

--- a/fixtures/number.md
+++ b/fixtures/number.md
@@ -11,31 +11,7 @@
                         </div>
                     </div>
                 </div>
-                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                    <div style="width:100%;height:auto;">
-                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                            <div style="height:auto;width:120px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:120px;min-width:120px;">
-                                <div style="float:left;width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:16px;color:#4C5264;line-height:18px;">street</div>
-                            </div>
-                            <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
-                                <div style="float:left;width:100%;height:auto;">
-                                    <div class="attributeTooltip" style="display:none;"><span class="attributeTooltipText">optional</span></div>
-                                </div>
-                            </div>
-                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
-                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                    <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:14px;color:#8A93A3;margin-bottom:4px;">number</div>
-                                </div>
-                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                    <div></div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
             </div>
         </div>

--- a/fixtures/string.md
+++ b/fixtures/string.md
@@ -11,31 +11,7 @@
                         </div>
                     </div>
                 </div>
-                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                    <div style="width:100%;height:auto;">
-                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                            <div style="height:auto;width:120px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:120px;min-width:120px;">
-                                <div style="float:left;width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:16px;color:#4C5264;line-height:18px;">street</div>
-                            </div>
-                            <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
-                                <div style="float:left;width:100%;height:auto;">
-                                    <div class="attributeTooltip" style="display:none;"><span class="attributeTooltipText">optional</span></div>
-                                </div>
-                            </div>
-                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
-                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                    <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:14px;color:#8A93A3;margin-bottom:4px;">string</div>
-                                </div>
-                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
-                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
-                                    <div></div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;"></div>
             </div>
         </div>

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "lodash": "4.6.1",
     "marked": "^0.3.5",
     "mocha": "^2.4.5",
-    "mson-zoo": "2.0.0",
+    "mson-zoo": "2.1.1",
     "node-noop": "^1.0.0",
     "protagonist": "^1.2.6",
     "radium": "^0.16.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attributes-kit",
-  "version": "0.14.3",
+  "version": "0.15.0",
   "description": "React component for MSON rendering",
   "engines": {
     "node": "5.7.x",

--- a/src/Attribute/Attribute.js
+++ b/src/Attribute/Attribute.js
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import Error from '../Error/Error';
 import refractToComponentsMap from '../refractToComponentMap';
 
 class Attribute extends React.Component {
@@ -18,7 +18,14 @@ class Attribute extends React.Component {
     const reactComponent = refractToComponentsMap[this.props.element.element];
 
     if (typeof reactComponent === 'undefined') {
-      return new Error(`Unable to find a rendering component for ${this.props.element.element}`);
+      const errorMessage = `
+        Attributes Kit is not able to render ‘${this.props.element.element}’
+        element.
+      `;
+
+      return (
+        <Error errorMessage={errorMessage} />
+      );
     }
 
     return React.createElement(reactComponent, {

--- a/src/Attributes/Attributes.js
+++ b/src/Attributes/Attributes.js
@@ -158,7 +158,7 @@ class Attributes extends React.Component {
         return false;
       }
 
-      if (!isArray(nestedElement.content)) {
+      if (nestedElement.content && !isArray(nestedElement.content)) {
         if (removeInherited && isInherited(nestedElement.content.value)) {
           return false;
         } else if (removeIncluded && isIncluded(nestedElement.content.value)) {

--- a/src/Error/Error.js
+++ b/src/Error/Error.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import merge from 'lodash/merge';
+
+class Error extends React.Component {
+  static propTypes = {
+    errorMessage: React.PropTypes.string,
+    style: React.PropTypes.object,
+  };
+
+  get style() {
+    const style = {
+      base: {
+        width: '100%',
+        height: 'auto',
+        color: '#4C5264',
+        backgroundColor: '#fff',
+        border: '1px solid rgb(213, 222, 237)',
+        paddingTop: '10px',
+        paddingBottom: '14px',
+        paddingLeft: '16px',
+        paddingRight: '16px',
+        borderRadius: '3px',
+        boxShadow: 'rgb(240, 241, 244) 0px 1px 1px 0px',
+      },
+      title: {
+        fontFamily: 'Source Sans Pro',
+        fontSize: '18px',
+        lineHeight: '150%',
+        fontWeight: '600',
+        marginBottom: '2px',
+        color: '#DD1711',
+      },
+      text: {
+        fontFamily: 'Source Sans Pro',
+        fontSize: '16px',
+        lineHeight: '125%',
+      },
+    };
+
+    return merge(style, this.props.style || {});
+  }
+
+  render() {
+    return (
+      <div style={this.style.base}>
+        <h3 style={this.style.title}>Uh-oh, an error occurred!</h3>
+        <p style={this.style.text}>{this.props.errorMessage}</p>
+      </div>
+    );
+  }
+}
+
+export default Error;

--- a/src/Primitive/Primitive.js
+++ b/src/Primitive/Primitive.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import merge from 'lodash/merge';
+
+import Row from '../Row/Row';
+import Type from '../Type/Type';
+import Column from '../Column/Column';
+import Value from '../Value/Value';
+import Description from '../Description/Description';
+
+
+class Primitive extends React.Component {
+  static propTypes = {
+    element: React.PropTypes.object,
+    style: React.PropTypes.object,
+  };
+
+  static contextTypes = {
+    theme: React.PropTypes.object,
+  };
+
+  get style() {
+    const { BORDER_COLOR } = this.context.theme;
+
+    const style = {
+      base: {
+
+      },
+      typeHeader: {
+        borderBottom: `1px solid ${BORDER_COLOR}`,
+        paddingBottom: '8px',
+        paddingLeft: '0px',
+        paddingTop: '4px',
+      },
+      type: {
+        root: {
+          fontSize: '12px',
+        },
+      },
+    };
+
+    return merge(style, this.props.style || {});
+  };
+
+  get type() {
+    const element = this.props.element;
+
+    if (element.meta && element.meta.id) {
+      return element.meta.id;
+    }
+
+    return element.element;
+  };
+
+  render() {
+    return (
+      <Column style={this.style.base}>
+        <Row style={this.style.typeHeader}>
+          <Type
+            type={this.type}
+            style={this.style.type}
+          />
+        </Row>
+
+        <Row>
+          <Description element={this.props.element} />
+        </Row>
+
+        <Row>
+          <Value element={this.props.element} />
+        </Row>
+      </Column>
+    );
+  };
+}
+
+export default Primitive;

--- a/src/refractToComponentMap.js
+++ b/src/refractToComponentMap.js
@@ -1,10 +1,22 @@
+import PrimitiveComponent from './Primitive/Primitive';
 import ArrayComponent from './Array/Array';
 import SelectComponent from './Select/Select';
 import ObjectComponent from './Object/Object';
 
 export default {
+  /**
+   * Primitive Types
+   */
+  boolean: PrimitiveComponent,
+  string: PrimitiveComponent,
+  number: PrimitiveComponent,
+
+  /**
+   * Structure Types
+   */
   object: ObjectComponent,
   select: SelectComponent,
+
   // Since Array and Enum elements have the same structure we'll
   // share the same component for rendering.
   array: ArrayComponent,


### PR DESCRIPTION
This adds support for primitive types rendering, e.g. [number](https://github.com/apiaryio/mson-zoo/blob/master/samples/number.md), [string](https://github.com/apiaryio/mson-zoo/blob/master/samples/string.md) and [boolean](https://github.com/apiaryio/mson-zoo/blob/master/samples/boolean.md).

---

@danielgtaylor 