### PR TITLE
Fix the ‘StructuredArrayItem’ component to render structured elements

### DIFF
--- a/fixtures/array-fixed-samples-complex.md
+++ b/fixtures/array-fixed-samples-complex.md
@@ -72,7 +72,84 @@
                                                             </div>
                                                         </div>
                                                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:0px;"><span style="position:absolute;top:8px;right:8px;font-family:Source Code Pro;font-size:14px;color:#C8CDD4;line-height:18px;">2</span>
-                                                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:8px;padding-right:8px;"></div>
+                                                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:8px;padding-right:8px;">
+                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                    <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                        <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;">
+                                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:none;padding-bottom:4px;padding-left:0px;padding-top:4px;">
+                                                                                    <div style="height:auto;width:20px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:20px;max-width:20px;">
+                                                                                        <div style="width:100%;height:auto;">
+                                                                                            <div style="width:100%;height:20px;background-repeat:no-repeat;background-position:left center;background-image:url([object Object]);background-size:12px 7px;"></div>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                                                                        <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:13px;color:#8A93A3;">object</div>
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;padding-left:6px;">
+                                                                                <div style="width:100%;height:auto;padding-left:13px;border-left:1px solid #E8EBEE;padding-bottom:0px;">
+                                                                                    <div style="width:100%;height:auto;">
+                                                                                        <div>
+                                                                                            <div>
+                                                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
+                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                                        <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">name</div>
+                                                                                                    </div>
+                                                                                                    <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
+                                                                                                        <div style="float:left;width:100%;height:auto;"></div>
+                                                                                                    </div>
+                                                                                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                                                                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                                                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                                                                                                <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:13px;color:#8A93A3;">string</div>
+                                                                                                            </div>
+                                                                                                        </div>
+                                                                                                    </div>
+                                                                                                </div>
+                                                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
+                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                                        <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">color</div>
+                                                                                                    </div>
+                                                                                                    <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
+                                                                                                        <div style="float:left;width:100%;height:auto;"></div>
+                                                                                                    </div>
+                                                                                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                                                                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                                                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                                                                                                <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:13px;color:#8A93A3;">string</div>
+                                                                                                            </div>
+                                                                                                        </div>
+                                                                                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                                                            <div style="float:left;width:auto;height:auto;margin:0px;padding:0px;font-weight:600;background-color:#f0f1f4;border-radius:4px;padding-top:2px;padding-bottom:2px;padding-left:4px;padding-right:4px;font-family:Source Sans Pro;font-size:13px;color:#4C5264;line-height:17px;">white</div>
+                                                                                                        </div>
+                                                                                                    </div>
+                                                                                                </div>
+                                                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
+                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                                        <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">description</div>
+                                                                                                    </div>
+                                                                                                    <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
+                                                                                                        <div style="float:left;width:100%;height:auto;"></div>
+                                                                                                    </div>
+                                                                                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                                                                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                                                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                                                                                                <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:13px;color:#8A93A3;">string</div>
+                                                                                                            </div>
+                                                                                                        </div>
+                                                                                                    </div>
+                                                                                                </div>
+                                                                                            </div>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
                                                         </div>
                                                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:none;padding-top:8px;padding-bottom:8px;"><span style="position:absolute;top:8px;right:8px;font-family:Source Code Pro;font-size:14px;color:#C8CDD4;line-height:18px;">3</span>
                                                             <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:28px;">

--- a/fixtures/array-of-arrays.md
+++ b/fixtures/array-of-arrays.md
@@ -37,7 +37,61 @@
                                                     </div>
                                                     <div style="width:100%;height:auto;border:1px solid #E8EBEE;">
                                                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:none;padding-top:8px;padding-bottom:8px;"><span style="position:absolute;top:8px;right:8px;font-family:Source Code Pro;font-size:14px;color:#C8CDD4;line-height:18px;">0</span>
-                                                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:8px;padding-right:8px;"></div>
+                                                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:8px;padding-right:8px;">
+                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                    <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                        <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border:1px solid #E8EBEE;border-bottom:none;padding-bottom:6px;padding-left:8px;padding-top:4px;background-color:#F8F8F9;">
+                                                                                <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:center;align-items:flex-start;">
+                                                                                    <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:13px;color:#8A93A3;">array</div>
+                                                                                </div>
+                                                                            </div>
+                                                                            <div style="width:100%;height:auto;border:1px solid #E8EBEE;">
+                                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;"><span style="position:absolute;top:8px;right:8px;font-family:Source Code Pro;font-size:14px;color:#C8CDD4;line-height:18px;">0</span>
+                                                                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:8px;">
+                                                                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                                            <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:13px;color:#8A93A3;">number</div>
+                                                                                        </div>
+                                                                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                                            <div style="float:left;width:auto;height:auto;margin:0px;padding:0px;font-weight:600;background-color:#f0f1f4;border-radius:4px;padding-top:2px;padding-bottom:2px;padding-left:4px;padding-right:4px;font-family:Source Sans Pro;font-size:13px;color:#4C5264;line-height:17px;">1</div>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                </div>
+                                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;"><span style="position:absolute;top:8px;right:8px;font-family:Source Code Pro;font-size:14px;color:#C8CDD4;line-height:18px;">1</span>
+                                                                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:8px;">
+                                                                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                                            <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:13px;color:#8A93A3;">number</div>
+                                                                                        </div>
+                                                                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                                            <div style="float:left;width:auto;height:auto;margin:0px;padding:0px;font-weight:600;background-color:#f0f1f4;border-radius:4px;padding-top:2px;padding-bottom:2px;padding-left:4px;padding-right:4px;font-family:Source Sans Pro;font-size:13px;color:#4C5264;line-height:17px;">2</div>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                </div>
+                                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;"><span style="position:absolute;top:8px;right:8px;font-family:Source Code Pro;font-size:14px;color:#C8CDD4;line-height:18px;">2</span>
+                                                                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:8px;">
+                                                                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                                            <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:13px;color:#8A93A3;">number</div>
+                                                                                        </div>
+                                                                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                                            <div style="float:left;width:auto;height:auto;margin:0px;padding:0px;font-weight:600;background-color:#f0f1f4;border-radius:4px;padding-top:2px;padding-bottom:2px;padding-left:4px;padding-right:4px;font-family:Source Sans Pro;font-size:13px;color:#4C5264;line-height:17px;">3</div>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                </div>
+                                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:none;padding-top:8px;padding-bottom:8px;"><span style="position:absolute;top:8px;right:8px;font-family:Source Code Pro;font-size:14px;color:#C8CDD4;line-height:18px;">3</span>
+                                                                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:8px;">
+                                                                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                                            <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:13px;color:#8A93A3;">number</div>
+                                                                                        </div>
+                                                                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                                            <div style="float:left;width:auto;height:auto;margin:0px;padding:0px;font-weight:600;background-color:#f0f1f4;border-radius:4px;padding-top:2px;padding-bottom:2px;padding-left:4px;padding-right:4px;font-family:Source Sans Pro;font-size:13px;color:#4C5264;line-height:17px;">4</div>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
                                                         </div>
                                                     </div>
                                                 </div>

--- a/fixtures/array-of-types-mixed-complex.md
+++ b/fixtures/array-of-types-mixed-complex.md
@@ -37,7 +37,69 @@
                                                     </div>
                                                     <div style="width:100%;height:auto;border:1px solid #E8EBEE;">
                                                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:0px;"><span style="position:absolute;top:8px;right:8px;font-family:Source Code Pro;font-size:14px;color:#C8CDD4;line-height:18px;">0</span>
-                                                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:8px;padding-right:8px;"></div>
+                                                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:8px;padding-right:8px;">
+                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                    <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                        <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;">
+                                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:none;padding-bottom:4px;padding-left:0px;padding-top:4px;">
+                                                                                    <div style="height:auto;width:20px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:20px;max-width:20px;">
+                                                                                        <div style="width:100%;height:auto;">
+                                                                                            <div style="width:100%;height:20px;background-repeat:no-repeat;background-position:left center;background-image:url([object Object]);background-size:12px 7px;"></div>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                                                                        <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:13px;color:#8A93A3;">object</div>
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;padding-left:6px;">
+                                                                                <div style="width:100%;height:auto;padding-left:13px;border-left:1px solid #E8EBEE;padding-bottom:0px;">
+                                                                                    <div style="width:100%;height:auto;">
+                                                                                        <div>
+                                                                                            <div>
+                                                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
+                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                                        <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">name</div>
+                                                                                                    </div>
+                                                                                                    <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
+                                                                                                        <div style="float:left;width:100%;height:auto;"></div>
+                                                                                                    </div>
+                                                                                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                                                                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                                                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                                                                                                <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:13px;color:#8A93A3;">string</div>
+                                                                                                            </div>
+                                                                                                        </div>
+                                                                                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                                                            <div style="float:left;width:auto;height:auto;margin:0px;padding:0px;font-weight:600;background-color:#f0f1f4;border-radius:4px;padding-top:2px;padding-bottom:2px;padding-left:4px;padding-right:4px;font-family:Source Sans Pro;font-size:13px;color:#4C5264;line-height:17px;">snow</div>
+                                                                                                        </div>
+                                                                                                    </div>
+                                                                                                </div>
+                                                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
+                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                                        <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">description</div>
+                                                                                                    </div>
+                                                                                                    <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
+                                                                                                        <div style="float:left;width:100%;height:auto;"></div>
+                                                                                                    </div>
+                                                                                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                                                                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                                                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                                                                                                <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:13px;color:#8A93A3;">string</div>
+                                                                                                            </div>
+                                                                                                        </div>
+                                                                                                    </div>
+                                                                                                </div>
+                                                                                            </div>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
                                                         </div>
                                                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:none;padding-top:8px;padding-bottom:8px;"><span style="position:absolute;top:8px;right:8px;font-family:Source Code Pro;font-size:14px;color:#C8CDD4;line-height:18px;">1</span>
                                                             <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:28px;">

--- a/fixtures/enum-containing-object.md
+++ b/fixtures/enum-containing-object.md
@@ -49,7 +49,72 @@
                                                         </div>
                                                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:none;padding-top:8px;padding-bottom:0px;">
                                                             <div style="height:auto;width:8px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:8px;max-width:8px;align-self:stretch;background-image:url([object Object]);background-size:8px 8px;background-repeat:no-repeat;background-position:center center;margin-left:16px;margin-right:8px;"></div>
-                                                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:8px;padding-right:8px;"></div>
+                                                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:8px;padding-right:8px;">
+                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                    <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                        <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;">
+                                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:none;padding-bottom:4px;padding-left:0px;padding-top:4px;">
+                                                                                    <div style="height:auto;width:20px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:20px;max-width:20px;">
+                                                                                        <div style="width:100%;height:auto;">
+                                                                                            <div style="width:100%;height:20px;background-repeat:no-repeat;background-position:left center;background-image:url([object Object]);background-size:12px 7px;"></div>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                                                                        <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:13px;color:#8A93A3;">object</div>
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                            <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;padding-left:6px;">
+                                                                                <div style="width:100%;height:auto;padding-left:13px;border-left:1px solid #E8EBEE;padding-bottom:0px;">
+                                                                                    <div style="width:100%;height:auto;">
+                                                                                        <div>
+                                                                                            <div>
+                                                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
+                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                                        <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">tag_id</div>
+                                                                                                    </div>
+                                                                                                    <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
+                                                                                                        <div style="float:left;width:100%;height:auto;"></div>
+                                                                                                    </div>
+                                                                                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                                                                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                                                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                                                                                                <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:13px;color:#8A93A3;">string</div>
+                                                                                                            </div>
+                                                                                                        </div>
+                                                                                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                                                            <div style="float:left;width:auto;height:auto;margin:0px;padding:0px;font-weight:600;background-color:#f0f1f4;border-radius:4px;padding-top:2px;padding-bottom:2px;padding-left:4px;padding-right:4px;font-family:Source Sans Pro;font-size:13px;color:#4C5264;line-height:17px;">1</div>
+                                                                                                        </div>
+                                                                                                    </div>
+                                                                                                </div>
+                                                                                                <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
+                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                                        <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">label</div>
+                                                                                                    </div>
+                                                                                                    <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
+                                                                                                        <div style="float:left;width:100%;height:auto;"></div>
+                                                                                                    </div>
+                                                                                                    <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                                                                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                                                            <div style="height:auto;width:100%;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
+                                                                                                                <div style="width:100%;font-family:Source Code Pro;font-weight:regular;font-size:13px;color:#8A93A3;">string</div>
+                                                                                                            </div>
+                                                                                                        </div>
+                                                                                                        <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
+                                                                                                            <div style="float:left;width:auto;height:auto;margin:0px;padding:0px;font-weight:600;background-color:#f0f1f4;border-radius:4px;padding-top:2px;padding-bottom:2px;padding-left:4px;padding-right:4px;font-family:Source Sans Pro;font-size:13px;color:#4C5264;line-height:17px;">green</div>
+                                                                                                        </div>
+                                                                                                    </div>
+                                                                                                </div>
+                                                                                            </div>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
                                                         </div>
                                                     </div>
                                                 </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attributes-kit",
-  "version": "0.17.0-alpha.1",
+  "version": "0.17.0-alpha.2",
   "description": "React component for MSON rendering",
   "engines": {
     "node": "5.7.x",

--- a/src/ArrayItem/StructuredArrayItem.js
+++ b/src/ArrayItem/StructuredArrayItem.js
@@ -11,7 +11,6 @@ import {
   hasDefaults,
   hasDescription,
   hasSamples,
-  hasValue,
   isArray,
   isLastArrayItem,
   isObject,
@@ -108,10 +107,6 @@ class StructuredArrayItem extends React.Component {
   }
 
   renderValue() {
-    if (!hasValue(this.props.element)) {
-      return null;
-    }
-
     return (
       <Row>
         {


### PR DESCRIPTION
This fixes a bug where objects in an array were not rendered.

```
- tags (array)
    - hello (string)
    - 42 (number)
    - (object)
        - name: snow (string)
        - color: white
        - description (string)
    - world
```

In this example, `(object)` wasn't displayed.