### PR TITLE
Ability to trigger (re)align of keys

### DIFF
--- a/fixtures/array-fixed-inline-samples.md
+++ b/fixtures/array-fixed-inline-samples.md
@@ -9,7 +9,7 @@
                     <div>
                         <div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">street</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -24,7 +24,7 @@
                                 </div>
                             </div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">city</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -39,7 +39,7 @@
                                 </div>
                             </div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">state</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">

--- a/fixtures/array-fixed-inline.md
+++ b/fixtures/array-fixed-inline.md
@@ -9,7 +9,7 @@
                     <div>
                         <div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">street</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -24,7 +24,7 @@
                                 </div>
                             </div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">city</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -39,7 +39,7 @@
                                 </div>
                             </div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">state</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">

--- a/fixtures/array-fixed-samples-complex.md
+++ b/fixtures/array-fixed-samples-complex.md
@@ -94,7 +94,7 @@
                                                                                         <div>
                                                                                             <div>
                                                                                                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                                                         <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">name</div>
                                                                                                     </div>
                                                                                                     <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -109,7 +109,7 @@
                                                                                                     </div>
                                                                                                 </div>
                                                                                                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                                                         <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">color</div>
                                                                                                     </div>
                                                                                                     <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -127,7 +127,7 @@
                                                                                                     </div>
                                                                                                 </div>
                                                                                                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                                                         <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">description</div>
                                                                                                     </div>
                                                                                                     <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">

--- a/fixtures/array-of-types-mixed-complex.md
+++ b/fixtures/array-of-types-mixed-complex.md
@@ -59,7 +59,7 @@
                                                                                         <div>
                                                                                             <div>
                                                                                                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                                                         <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">name</div>
                                                                                                     </div>
                                                                                                     <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -77,7 +77,7 @@
                                                                                                     </div>
                                                                                                 </div>
                                                                                                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                                                         <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">description</div>
                                                                                                     </div>
                                                                                                     <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">

--- a/fixtures/description.md
+++ b/fixtures/description.md
@@ -9,7 +9,7 @@
                     <div>
                         <div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">id</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -52,7 +52,7 @@
                                 </div>
                             </div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">name</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -95,7 +95,7 @@
                                 </div>
                             </div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">price</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">

--- a/fixtures/enum-containing-object.md
+++ b/fixtures/enum-containing-object.md
@@ -71,7 +71,7 @@
                                                                                         <div>
                                                                                             <div>
                                                                                                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                                                         <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">tag_id</div>
                                                                                                     </div>
                                                                                                     <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -89,7 +89,7 @@
                                                                                                     </div>
                                                                                                 </div>
                                                                                                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                                                         <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">label</div>
                                                                                                     </div>
                                                                                                     <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">

--- a/fixtures/escaping.md
+++ b/fixtures/escaping.md
@@ -69,7 +69,7 @@
                                                             <div>
                                                                 <div>
                                                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                             <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">description</div>
                                                                         </div>
                                                                         <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -84,7 +84,7 @@
                                                                         </div>
                                                                     </div>
                                                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                             <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">date_listed</div>
                                                                         </div>
                                                                         <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -99,7 +99,7 @@
                                                                         </div>
                                                                     </div>
                                                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                             <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">some:location</div>
                                                                         </div>
                                                                         <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">

--- a/fixtures/object-complex.md
+++ b/fixtures/object-complex.md
@@ -9,7 +9,7 @@
                     <div>
                         <div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">id</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -27,7 +27,7 @@
                                 </div>
                             </div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">name</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -45,7 +45,7 @@
                                 </div>
                             </div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">price</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -185,7 +185,7 @@
                                 </div>
                             </div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">available</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">

--- a/fixtures/object-fixed-optional.md
+++ b/fixtures/object-fixed-optional.md
@@ -36,7 +36,7 @@
                                                             <div>
                                                                 <div>
                                                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                             <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">first_name</div>
                                                                         </div>
                                                                         <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -51,7 +51,7 @@
                                                                         </div>
                                                                     </div>
                                                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                             <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">last_name</div>
                                                                         </div>
                                                                         <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">

--- a/fixtures/object-fixed-values.md
+++ b/fixtures/object-fixed-values.md
@@ -36,7 +36,7 @@
                                                             <div>
                                                                 <div>
                                                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                             <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">first_name</div>
                                                                         </div>
                                                                         <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -54,7 +54,7 @@
                                                                         </div>
                                                                     </div>
                                                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                             <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">last_name</div>
                                                                         </div>
                                                                         <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">

--- a/fixtures/object-fixed.md
+++ b/fixtures/object-fixed.md
@@ -36,7 +36,7 @@
                                                             <div>
                                                                 <div>
                                                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                             <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">first_name</div>
                                                                         </div>
                                                                         <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -51,7 +51,7 @@
                                                                         </div>
                                                                     </div>
                                                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                             <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">last_name</div>
                                                                         </div>
                                                                         <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">

--- a/fixtures/object-simple.md
+++ b/fixtures/object-simple.md
@@ -36,7 +36,7 @@
                                                             <div>
                                                                 <div>
                                                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                             <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">street</div>
                                                                         </div>
                                                                         <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -51,7 +51,7 @@
                                                                         </div>
                                                                     </div>
                                                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                             <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">city</div>
                                                                         </div>
                                                                         <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -66,7 +66,7 @@
                                                                         </div>
                                                                     </div>
                                                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                             <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">state</div>
                                                                         </div>
                                                                         <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">

--- a/fixtures/object-very-complex.md
+++ b/fixtures/object-very-complex.md
@@ -9,7 +9,7 @@
                     <div>
                         <div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">id</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -27,7 +27,7 @@
                                 </div>
                             </div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">name</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -45,7 +45,7 @@
                                 </div>
                             </div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">price</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -212,7 +212,7 @@
                                                             <div>
                                                                 <div>
                                                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;min-width:auto;max-width:auto;">
+                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;">
                                                                             <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">street</div>
                                                                         </div>
                                                                         <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -227,7 +227,7 @@
                                                                         </div>
                                                                     </div>
                                                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;min-width:auto;max-width:auto;">
+                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;">
                                                                             <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">number</div>
                                                                         </div>
                                                                         <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -242,7 +242,7 @@
                                                                         </div>
                                                                     </div>
                                                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;min-width:auto;max-width:auto;">
+                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;">
                                                                             <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">zip_code</div>
                                                                         </div>
                                                                         <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -284,7 +284,7 @@
                                                                                                     <div>
                                                                                                         <div>
                                                                                                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                                                                                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                                                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">name</div>
                                                                                                                 </div>
                                                                                                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -299,7 +299,7 @@
                                                                                                                 </div>
                                                                                                             </div>
                                                                                                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                                                                                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                                                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">code</div>
                                                                                                                 </div>
                                                                                                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">

--- a/fixtures/one-of-complex.md
+++ b/fixtures/one-of-complex.md
@@ -9,7 +9,7 @@
                     <div>
                         <div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">name</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -32,7 +32,7 @@
                                                 <div>
                                                     <div>
                                                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                                            <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                            <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                 <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">city</div>
                                                             </div>
                                                             <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -61,7 +61,7 @@
                                                 <div>
                                                     <div>
                                                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                                            <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                            <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                 <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">town</div>
                                                             </div>
                                                             <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -95,7 +95,7 @@
                                                 <div>
                                                     <div>
                                                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                                            <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                            <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                 <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">state</div>
                                                             </div>
                                                             <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -132,7 +132,7 @@
                                                                             <div>
                                                                                 <div>
                                                                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                                             <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">province</div>
                                                                                         </div>
                                                                                         <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -161,7 +161,7 @@
                                                                             <div>
                                                                                 <div>
                                                                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                                             <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">territory</div>
                                                                                         </div>
                                                                                         <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -198,7 +198,7 @@
                                 </div>
                             </div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">country</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">

--- a/fixtures/one-of-properties.md
+++ b/fixtures/one-of-properties.md
@@ -44,7 +44,7 @@
                                                                                         <div>
                                                                                             <div>
                                                                                                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                                                         <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">first_name</div>
                                                                                                     </div>
                                                                                                     <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -59,7 +59,7 @@
                                                                                                     </div>
                                                                                                 </div>
                                                                                                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                                                         <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">last_name</div>
                                                                                                     </div>
                                                                                                     <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -88,7 +88,7 @@
                                                                                         <div>
                                                                                             <div>
                                                                                                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                                    <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                                                         <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">full_name</div>
                                                                                                     </div>
                                                                                                     <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">

--- a/fixtures/one-of.md
+++ b/fixtures/one-of.md
@@ -9,7 +9,7 @@
                     <div>
                         <div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">city</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -32,7 +32,7 @@
                                                 <div>
                                                     <div>
                                                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                                            <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                            <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                 <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">state</div>
                                                             </div>
                                                             <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -61,7 +61,7 @@
                                                 <div>
                                                     <div>
                                                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                                            <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                            <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                 <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">province</div>
                                                             </div>
                                                             <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">
@@ -87,7 +87,7 @@
                                 </div>
                             </div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;padding-left:20px;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">country</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">

--- a/fixtures/optional.md
+++ b/fixtures/optional.md
@@ -9,7 +9,7 @@
                     <div>
                         <div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">street</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">

--- a/fixtures/required-object.md
+++ b/fixtures/required-object.md
@@ -36,7 +36,7 @@
                                                             <div>
                                                                 <div>
                                                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                        <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                             <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">count</div>
                                                                         </div>
                                                                         <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">

--- a/fixtures/required.md
+++ b/fixtures/required.md
@@ -9,7 +9,7 @@
                     <div>
                         <div>
                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">street</div>
                                 </div>
                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">

--- a/fixtures/variable-property.md
+++ b/fixtures/variable-property.md
@@ -63,7 +63,7 @@
                                                                                                     <div>
                                                                                                         <div>
                                                                                                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:0px;padding-top:8px;padding-bottom:8px;">
-                                                                                                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;min-width:auto;max-width:auto;">
+                                                                                                                <div style="height:auto;width:auto;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;">
                                                                                                                     <div style="width:100%;height:auto;font-family:Source Code Pro;font-weight:500;font-size:13px;color:rgb(48, 52, 63);line-height:17px;user-select:none;">href</div>
                                                                                                                 </div>
                                                                                                                 <div style="height:auto;width:25px;display:flex;flex-direction:column;flex-wrap:no-wrap;justify-content:flex-start;align-items:flex-start;max-width:25px;min-width:25px;">

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "eslint-config-airbnb": "6.0.2",
     "eslint-plugin-react": "4.1.0",
     "express": "^4.13.3",
+    "fbemitter": "^2.0.2",
     "file-loader": "^0.8.4",
     "flux": "^2.1.1",
     "history": "1.14.0",

--- a/playground/components/Playground.js
+++ b/playground/components/Playground.js
@@ -94,18 +94,26 @@ class Playground extends React.Component {
   };
 
   toggleCollapseByDefault = () => {
+    console.debug(`
+      Setting the ‘collapseByDefault’ option to ‘${!this.state.collapseByDefault}’...
+    `);
+
     this.setState({
       collapseByDefault: !this.state.collapseByDefault,
     });
   };
 
   toggleNamedTypes = () => {
+    console.debug(`Setting the ‘namedTypes’ option to ‘${!this.state.namedTypes}’...`);
+
     this.setState({
       namedTypes: !this.state.namedTypes,
     });
   };
 
   alignKeys = () => {
+    console.debug('Triggering alignment of keys...');
+
     this.refs.attributes.alignKeys();
   };
 

--- a/playground/components/Playground.js
+++ b/playground/components/Playground.js
@@ -105,6 +105,10 @@ class Playground extends React.Component {
     });
   };
 
+  alignKeys = () => {
+    this.refs.attributes.alignKeys();
+  };
+
   render() {
     const dataStructures = this.state.parseResult.dataStructures || [];
 
@@ -229,11 +233,24 @@ class Playground extends React.Component {
                 onChange={this.toggleCollapseByDefault}
               />
             </div>
+
+            <div>
+              <label>
+                Align keys
+              </label>
+              <br />
+              <input
+                type="button"
+                onClick={this.alignKeys}
+                value="Align keys"
+              />
+            </div>
           </div>
 
           {
             dataStructures.length > 0 &&
               <AttributesKit.Attributes
+                ref="attributes"
                 collapseByDefault={this.state.collapseByDefault}
                 dataStructures={dataStructures}
                 element={this.state.parseResult.dataStructures[0]}

--- a/src/Attributes/Attributes.js
+++ b/src/Attributes/Attributes.js
@@ -1,11 +1,12 @@
 import abagnale from 'abagnale/lib/abagnale';
 import cloneDeep from 'lodash/cloneDeep';
 import eidolon from 'eidolon';
+import {EventEmitter} from 'fbemitter';
 import isUndefined from 'lodash/isUndefined';
 import map from 'lodash/map';
-import reduce from 'lodash/reduce';
 import merge from 'lodash/merge';
 import React from 'react';
+import reduce from 'lodash/reduce';
 
 import Attribute from '../Attribute/Attribute';
 import Title from '../Title/Title';
@@ -44,6 +45,7 @@ class Attributes extends React.Component {
     dereferencedDataStructures: React.PropTypes.array,
     theme: React.PropTypes.object,
     namedTypes: React.PropTypes.bool,
+    eventEmitter: React.PropTypes.object,
     onElementLinkClick: React.PropTypes.func,
     includedProperties: React.PropTypes.oneOfType([
       React.PropTypes.bool,
@@ -58,11 +60,13 @@ class Attributes extends React.Component {
   constructor(props) {
     super(props);
     this.state = this.transformPropsIntoState(this.props);
+    this.eventEmitter = new EventEmitter();
   };
 
   getChildContext() {
     return {
       dereferencedDataStructures: this.state.dereferencedDataStructures,
+      eventEmitter: this.eventEmitter,
       includedProperties: this.state.includedProperties,
       inheritedProperties: this.state.inheritedProperties,
       onElementLinkClick: this.state.onElementLinkClick,
@@ -75,6 +79,10 @@ class Attributes extends React.Component {
     this.setState(
       this.transformPropsIntoState(nextProps)
     );
+  };
+
+  alignKeys = () => {
+    this.eventEmitter.emit('alignKeys');
   };
 
   transformPropsIntoState(props) {

--- a/src/Attributes/Attributes.js
+++ b/src/Attributes/Attributes.js
@@ -1,7 +1,7 @@
 import abagnale from 'abagnale/lib/abagnale';
 import cloneDeep from 'lodash/cloneDeep';
 import eidolon from 'eidolon';
-import {EventEmitter} from 'fbemitter';
+import { EventEmitter } from 'fbemitter';
 import isUndefined from 'lodash/isUndefined';
 import map from 'lodash/map';
 import merge from 'lodash/merge';

--- a/src/ObjectProperties/ObjectProperties.js
+++ b/src/ObjectProperties/ObjectProperties.js
@@ -30,6 +30,7 @@ class ObjectProperties extends React.Component {
 
   static contextTypes = {
     theme: React.PropTypes.object,
+    eventEmitter: React.PropTypes.object,
     includedProperties: React.PropTypes.oneOfType([
       React.PropTypes.bool,
       React.PropTypes.string,
@@ -48,7 +49,28 @@ class ObjectProperties extends React.Component {
     };
 
     this.keyWidthsIndex = {};
-  }
+  };
+
+  componentDidMount = () => {
+    // Everytime the `alignKeys` event is emitted, we'll re-align the keys.
+    this.subscription = this.context.eventEmitter.addListener('alignKeys', this.alignKeys);
+  };
+
+  componentWillUnmount = () => {
+    this.subscription.remove();
+  };
+
+  alignKeys = () => {
+    this.keyWidthsIndex = {};
+
+    this.setState({
+      keyWidth: null,
+    });
+
+    window.setTimeout(() => {
+      this.context.eventEmitter.emit('alignKey');
+    }, 10);
+  };
 
   getComponent(element, { key, index }) {
     if (!key) {
@@ -108,11 +130,14 @@ class ObjectProperties extends React.Component {
   }
 
   reportKeyWidth = (keyIdentifier, keyWidth) => {
+    console.log('reportKeyWidth', keyIdentifier, keyWidth);
+
     this.keyWidthsIndex[keyIdentifier] = keyWidth;
 
     const keyWidths = values(this.keyWidthsIndex);
 
     if (keyWidths.length === this.props.element.content.length) {
+      console.log('Setting to ', max(keyWidths))
       this.setState({
         keyWidth: max(keyWidths),
       });

--- a/src/ObjectProperties/ObjectProperties.js
+++ b/src/ObjectProperties/ObjectProperties.js
@@ -60,18 +60,6 @@ class ObjectProperties extends React.Component {
     this.subscription.remove();
   };
 
-  alignKeys = () => {
-    this.keyWidthsIndex = {};
-
-    this.setState({
-      keyWidth: null,
-    });
-
-    window.setTimeout(() => {
-      this.context.eventEmitter.emit('alignKey');
-    }, 10);
-  };
-
   getComponent(element, { key, index }) {
     if (!key) {
       key = index;
@@ -113,6 +101,18 @@ class ObjectProperties extends React.Component {
     );
   }
 
+  alignKeys = () => {
+    this.keyWidthsIndex = {};
+
+    this.setState({
+      keyWidth: null,
+    });
+
+    window.setTimeout(() => {
+      this.context.eventEmitter.emit('alignKey');
+    }, 10);
+  };
+
   get style() {
     const style = {
       root: {
@@ -130,19 +130,16 @@ class ObjectProperties extends React.Component {
   }
 
   reportKeyWidth = (keyIdentifier, keyWidth) => {
-    console.log('reportKeyWidth', keyIdentifier, keyWidth);
-
     this.keyWidthsIndex[keyIdentifier] = keyWidth;
 
     const keyWidths = values(this.keyWidthsIndex);
 
     if (keyWidths.length === this.props.element.content.length) {
-      console.log('Setting to ', max(keyWidths))
       this.setState({
         keyWidth: max(keyWidths),
       });
     }
-  }
+  };
 
   groupElements() {
     const elements = this.props.element.content;

--- a/src/ObjectProperty/StructuredObjectProperty.js
+++ b/src/ObjectProperty/StructuredObjectProperty.js
@@ -73,14 +73,14 @@ class StructuredObjectProperty extends React.Component {
     this.subscription = this.context.eventEmitter.addListener('alignKey', this.alignKey);
   };
 
-  componentWillUnmount = () => {
-    this.subscription.remove();
-  };
-
   componentWillReceiveProps = (nextProps) => {
     this.setState(
       this.transformPropsIntoState(nextProps)
     );
+  };
+
+  componentWillUnmount = () => {
+    this.subscription.remove();
   };
 
   alignKey = () => {


### PR DESCRIPTION
Now, you can manually trigger an alignment of keys.

This is useful mainly when you call `react.createElement` and `reactDom.render(reactElement, container)` *before the `container` element is inserted in the DOM* (= `reactDom.findDOMNode(...).clientWidth` returns `0`).

Idea here is to do it automatically (e.g. when a key gets longer, on `window.onresize`, ...) in the future.

## Preview

![alignkeys](https://cloud.githubusercontent.com/assets/95191/14386488/5556fa6a-fda5-11e5-82b7-214d66e9717f.gif)
