### PR TITLE
0.17

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,8 +2,8 @@
 
 |       | Version |
 |:------|:--------|
-| NPM   | `0.16.0`  |
-| [Apiary](https://apiary.io) | `0.15.1` |
+| NPM   | `0.17.0`  |
+| [Apiary](https://apiary.io) | `0.17` |
 
 This table indicates what's the _latest version of the Attributes Kit available in the NPM Registry_ and what's the _latest version that has been deployed_ to [Apiary](https://apiary.io).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attributes-kit",
-  "version": "0.17.0-alpha.3",
+  "version": "0.17.0",
   "description": "React component for MSON rendering",
   "engines": {
     "node": "5.7.x",

--- a/playground/components/Examples.js
+++ b/playground/components/Examples.js
@@ -45,7 +45,6 @@ class Examples extends React.Component {
             element={fixture.parsed[0]}
             collapseByDefault={false}
             maxInheritanceDepth={undefined}
-            inheritanceTree={false}
             includedProperties="show"
             inheritedProperties="show"
           />

--- a/playground/components/Playground.js
+++ b/playground/components/Playground.js
@@ -13,7 +13,6 @@ class Playground extends React.Component {
     this.state = {
       title: true,
       collapseByDefault: true,
-      maxInheritanceDepth: undefined,
       namedTypes: false,
       includedProperties: 'show',
       inheritedProperties: 'show',
@@ -73,14 +72,6 @@ class Playground extends React.Component {
     console.debug(`Setting the ‘includedProperties’ option to ‘${value}’...`);
     this.setState({
       includedProperties: value,
-    });
-  };
-
-  toggleInheritanceDepth = (eventObject) => {
-    const value = parseInt(eventObject.currentTarget.value, 10);
-    console.debug(`Setting the ‘maxInheritanceDepth’ option to ‘${value}’...`);
-    this.setState({
-      maxInheritanceDepth: value,
     });
   };
 
@@ -169,19 +160,6 @@ class Playground extends React.Component {
             </div>
 
             <div>
-              <label htmlFor="inheritanceDepthInput">
-                Inheritance Depth
-              </label>
-              <br />
-              <input
-                type="text"
-                id="inheritanceDepthInput"
-                onChange={this.toggleInheritanceDepth}
-                placeholder="Infinity"
-              />
-            </div>
-
-            <div>
               <label htmlFor="namedTypesCheckbox">
                 Named Types
               </label>
@@ -215,7 +193,6 @@ class Playground extends React.Component {
                 element={this.state.parseResult.dataStructures[0]}
                 includedProperties={this.state.includedProperties}
                 inheritedProperties={this.state.inheritedProperties}
-                maxInheritanceDepth={this.state.maxInheritanceDepth}
                 onElementLinkClick={this.onElementLinkClick}
                 title={this.state.title}
                 namedTypes={this.state.namedTypes}

--- a/playground/components/Playground.js
+++ b/playground/components/Playground.js
@@ -14,7 +14,6 @@ class Playground extends React.Component {
       title: true,
       collapseByDefault: true,
       maxInheritanceDepth: undefined,
-      inheritanceTree: true,
       namedTypes: false,
       includedProperties: 'show',
       inheritedProperties: 'show',
@@ -74,14 +73,6 @@ class Playground extends React.Component {
     console.debug(`Setting the ‘includedProperties’ option to ‘${value}’...`);
     this.setState({
       includedProperties: value,
-    });
-  };
-
-  toggleInheritanceTree = (eventObject) => {
-    const value = eventObject.currentTarget.value;
-    console.debug(`Setting the ‘inheritanceTree’ option to ‘${value}’...`);
-    this.setState({
-      inheritanceTree: value,
     });
   };
 
@@ -178,21 +169,6 @@ class Playground extends React.Component {
             </div>
 
             <div>
-              <label htmlFor="inheritanceTreeSelect">
-                Inheritance Tree
-              </label>
-              <br />
-              <select
-                id="inheritanceTreeSelect"
-                onChange={this.toggleInheritanceTree}
-              >
-                <option value="show">Show</option>
-                <option value="hide">Hide</option>
-                <option value="compact">Compact</option>
-              </select>
-            </div>
-
-            <div>
               <label htmlFor="inheritanceDepthInput">
                 Inheritance Depth
               </label>
@@ -238,7 +214,6 @@ class Playground extends React.Component {
                 dataStructures={dataStructures}
                 element={this.state.parseResult.dataStructures[0]}
                 includedProperties={this.state.includedProperties}
-                inheritanceTree={this.state.inheritanceTree}
                 inheritedProperties={this.state.inheritedProperties}
                 maxInheritanceDepth={this.state.maxInheritanceDepth}
                 onElementLinkClick={this.onElementLinkClick}

--- a/scripts/generateFixtures.js
+++ b/scripts/generateFixtures.js
@@ -33,7 +33,6 @@ msonZoo.samples.forEach((sample) => {
       element: result[0],
       collapseByDefault: false,
       maxInheritanceDepth: undefined,
-      inheritanceTree: false,
       includedProperties: 'show',
       inheritedProperties: 'show',
     });

--- a/src/Attributes/Attributes.js
+++ b/src/Attributes/Attributes.js
@@ -9,7 +9,6 @@ import React from 'react';
 
 import Attribute from '../Attribute/Attribute';
 import Title from '../Title/Title';
-import InheritanceTree from '../InheritanceTree/InheritanceTree';
 
 import defaultTheme from '../theme';
 
@@ -20,10 +19,6 @@ class Attributes extends React.Component {
     dataStructures: React.PropTypes.array,
     element: React.PropTypes.object,
     includedProperties: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.string,
-    ]),
-    inheritanceTree: React.PropTypes.oneOfType([
       React.PropTypes.bool,
       React.PropTypes.string,
     ]),
@@ -136,16 +131,6 @@ class Attributes extends React.Component {
       title = true;
     }
 
-    let inheritanceTree;
-
-    if (props.inheritanceTree === 'show') {
-      inheritanceTree = true;
-    } else if (props.inheritanceTree === 'hide') {
-      inheritanceTree = false;
-    } else {
-      inheritanceTree = true;
-    }
-
     const maxInheritanceDepth = props.maxInheritanceDepth || undefined;
 
     // Set default value of `collapseByDefault` option. If a user hasn't
@@ -185,7 +170,6 @@ class Attributes extends React.Component {
       dereferencedDataStructures,
       element,
       includedProperties,
-      inheritanceTree,
       inheritedProperties,
       maxInheritanceDepth,
       namedTypes,
@@ -212,15 +196,6 @@ class Attributes extends React.Component {
         {
           this.state.title &&
             <Title element={this.state.element} />
-        }
-
-        {
-          this.state.inheritanceTree &&
-            <InheritanceTree
-              element={this.state.element}
-              dataStructures={this.props.dataStructures}
-              dereferencedDataStructures={this.state.dereferencedDataStructures}
-            />
         }
 
         <Attribute

--- a/test/fixturesComparision.js
+++ b/test/fixturesComparision.js
@@ -34,7 +34,6 @@ describe('Comparision with reference fixtures', () => {
           element: result[0],
           collapseByDefault: false,
           maxInheritanceDepth: undefined,
-          inheritanceTree: false,
           includedProperties: 'show',
           inheritedProperties: 'show',
         });


### PR DESCRIPTION
This PR aims to release stable version of 0.17 and to end the first iteration of Named Types (inheritance, includes, ...) support.

## To Dos

* [x] Remove the `inheritanceTree` option, we'll expose the `InheritanceTree` component separately
* [x] Remove the `maxInheritanceDepth` option from Playground, we are planning to get back to it soon

## Next Steps

Here I outlined some of the next steps after the 0.17 release.

1. First iteration of Named Types (0.17)
  * [x] `inheritedProperties` set to `show` works flawlessly
  * [x] `includedProperties` set to `show` works flawlessly
  * [x] Ability to disable Named Types (https://github.com/apiaryio/attributes-kit/pull/230)
  * [x] Possibility to trigger (re)alignment of keys (https://github.com/apiaryio/attributes-kit/pull/231)
2. Major readability improvements & circular references (0.18?)
  * In progress
  * https://github.com/apiaryio/attributes-kit/pull/232
3. Get back to Named Types (0.19)
  * Rename Attributes Kit to Data Structures Kit
  * Expose `InheritanceTree` component separately
  * Support the `maxInheritanceDepth` option
  * Fix edge cases of `inheritedProperties` and `includedProperties` options
