### PR TITLE
Implement refract tree preprocessor

### DIFF
--- a/src/Attributes/Attributes.js
+++ b/src/Attributes/Attributes.js
@@ -12,7 +12,7 @@ import reduce from 'lodash/reduce';
 
 import Attribute from '../Attribute/Attribute';
 import Title from '../Title/Title';
-import {preprocess} from '../Preprocessor/Preprocessor';
+import { preprocess } from '../Preprocessor/Preprocessor';
 
 import defaultTheme from '../theme';
 

--- a/src/Attributes/Attributes.js
+++ b/src/Attributes/Attributes.js
@@ -12,6 +12,7 @@ import reduce from 'lodash/reduce';
 
 import Attribute from '../Attribute/Attribute';
 import Title from '../Title/Title';
+import {preprocess} from '../Preprocessor/Preprocessor';
 
 import defaultTheme from '../theme';
 
@@ -180,6 +181,8 @@ class Attributes extends React.Component {
     );
 
     const element = abagnale.forge([dereferencedElement], { separator: '.' })[0];
+
+    preprocess(element);
 
     return {
       collapseByDefault,

--- a/src/Preprocessor/Preprocessor.js
+++ b/src/Preprocessor/Preprocessor.js
@@ -63,6 +63,41 @@ export class Preprocessor {
   value() {
     return this.refract;
   }
+
+  /*
+   * Sorts inherited members either as the first members or the last members.
+   * This sort is stable. Passing `head` as `true` puts inherited members first,
+   * otherwise they go last.
+   */
+  sortInherited(head = true) {
+    if (this.refract && this.refract.content && this.refract.content.length) {
+      const inherited = [];
+      const others = [];
+
+      let result;
+
+      // We are not using `array.sort(...)` because it may not be stable!
+      // The order of items matters because we want to keep the order
+      // that was given by the user - it may have semantic meaning.
+      for (const item of this.refract.content) {
+        if (item.cache && item.cache.isInherited) {
+          inherited.push(item);
+        } else {
+          others.push(item);
+        }
+      }
+
+      if (head) {
+        result = inherited.concat(others);
+      } else {
+        result = others.concat(inherited);
+      }
+
+      this.refract.content = result;
+    }
+
+    return this;
+  }
 }
 
 export function preprocess(refract) {

--- a/src/Preprocessor/Preprocessor.js
+++ b/src/Preprocessor/Preprocessor.js
@@ -1,0 +1,70 @@
+/*
+ * Refract Preprocessor
+ * Adds useful shortcut information and otherwise processes refract structures
+ * so that rendering elements via React components is simpler.
+ */
+
+import * as contains from './contains';
+import * as has from './has';
+import * as is from './is';
+
+function processElement(refract) {
+  if (refract.cache) {
+    // This item has already been preprocessed!
+    // You can force reprocessing by deleting `refract.cache`.
+    return;
+  }
+
+  // First, set various things on the element
+  has.defaultValue(refract);
+  has.samples(refract);
+  has.description(refract);
+
+  is.arrayType(refract);
+  is.enumType(refract);
+  is.selectType(refract);
+  is.objectType(refract);
+
+  is.included(refract);
+  is.inherited(refract);
+
+  is.structured(refract);
+  is.referenced(refract);
+
+  // Then, see if it has children and process each of the children as well!
+  if (refract.content) {
+    if (refract.element === 'member' && refract.content.value) {
+      // This is a member of an object
+      processElement(refract.content.value);
+    } else if (refract.content.length && refract.content[0].element) {
+      // This is an array of items
+      for (const item of refract.content) {
+        processElement(item);
+      }
+    }
+  }
+
+  // This must be done *AFTER* all children are processed, because it
+  // depends on values set in the loop above.
+  contains.structuredElement(refract);
+}
+
+export class Preprocessor {
+  constructor(refract) {
+    this.refract = refract;
+  }
+
+  process() {
+    processElement(this.refract);
+
+    return this;
+  }
+
+  value() {
+    return this.refract;
+  }
+}
+
+export function preprocess(refract) {
+  return new Preprocessor(refract).process().value();
+}

--- a/src/Preprocessor/README.md
+++ b/src/Preprocessor/README.md
@@ -1,0 +1,35 @@
+# Preprocessor
+
+This module provides a way to preprocess a dereferenced tree of refract elements to add useful information into a cache that is later used to render React components on a web page. The purpose is to speed up rendering and simplify complex logic inside of components.
+
+This library modifies the refract structure in-place.
+
+## Usage
+
+There are two ways to use this functionality: a convenience method and by instantiating the class manually.
+
+```js
+import {preprocess, Preprocessor} from 'Preprocessor/Preprocessor';
+
+// Convenience layer, returns the in-place modified refract
+preprocess(refract);
+
+// Manually doing it, call `.value()` to get refract back
+new Preprocessor(refract).process();
+```
+
+### Using the Cache
+
+The preprocessor adds a new top-level property to each element, called `cache` and can be accessed like so:
+
+```js
+if (refract.cache.isArray) {
+  console.log('I am an array!');
+} else if (refract.cache.isStructured) {
+  console.log('I am structured but not an array!');
+}
+```
+
+## List of Cached Information
+
+**TODO** This section contains a list of all values you will find under the element's `cache` key and what they mean.

--- a/src/Preprocessor/contains.js
+++ b/src/Preprocessor/contains.js
@@ -1,4 +1,4 @@
-import {setCache} from './utilities';
+import { setCache } from './utilities';
 
 // This assumes that `cache.isStructured` has already
 // been set on any child elements!

--- a/src/Preprocessor/contains.js
+++ b/src/Preprocessor/contains.js
@@ -1,0 +1,18 @@
+import {setCache} from './utilities';
+
+// This assumes that `cache.isStructured` has already
+// been set on any child elements!
+export function structuredElement(refract) {
+  let containsStructured = false;
+
+  if (refract && refract.content && refract.content.length) {
+    for (const item of refract.content) {
+      if (item.cache && item.cache.isStructured) {
+        containsStructured = true;
+        break;
+      }
+    }
+  }
+
+  setCache(refract, 'containsStructuredElement', containsStructured);
+}

--- a/src/Preprocessor/has.js
+++ b/src/Preprocessor/has.js
@@ -1,0 +1,32 @@
+import isEmpty from 'lodash/isEmpty';
+import {setCache} from './utilities';
+
+export function defaultValue(refract) {
+  let hasDefault = false;
+
+  if (refract && refract.attributes && refract.attributes.default !== undefined) {
+    hasDefault = true;
+  }
+
+  setCache(refract, 'hasDefault', hasDefault);
+}
+
+export function samples(refract) {
+  let hasSamples = false;
+
+  if (refract && refract.attributes && !isEmpty(refract.attributes.samples)) {
+    hasSamples = true;
+  }
+
+  setCache(refract, 'hasSamples', hasSamples);
+}
+
+export function description(refract) {
+  let hasDescription = false;
+
+  if (refract && refract.meta && refract.meta.description) {
+    hasDescription = true;
+  }
+
+  setCache(refract, 'hasDescription', hasDescription);
+}

--- a/src/Preprocessor/has.js
+++ b/src/Preprocessor/has.js
@@ -1,5 +1,5 @@
 import isEmpty from 'lodash/isEmpty';
-import {setCache} from './utilities';
+import { setCache } from './utilities';
 
 export function defaultValue(refract) {
   let hasDefault = false;

--- a/src/Preprocessor/is.js
+++ b/src/Preprocessor/is.js
@@ -1,0 +1,97 @@
+import every from 'lodash/every';
+import isEmpty from 'lodash/isEmpty';
+import sift from 'sift';
+import TYPES from '../types';
+
+import {QUERIES} from '../queries';
+import {setCache} from './utilities';
+
+const {includedMember, inheritedMember} = QUERIES;
+
+function isType(refract, type) {
+  let isType = false;
+
+  if (refract) {
+    if (refract === type) {
+      isType = true;
+    }
+
+    if (refract.element === type) {
+      isType = true;
+    } else if (refract.element === 'member') {
+      // This is a member of an object, so we really care about the
+      // type of its value, e.g. `string` rather than `member`.
+      if (refract.content && refract.content.value && refract.content.value.element === type) {
+        isType = true;
+      }
+    }
+  }
+
+  return isType;
+}
+
+export function arrayType(refract) {
+  setCache(refract, 'isArray', isType(refract, TYPES.ARRAY));
+}
+
+export function enumType(refract) {
+  setCache(refract, 'isEnum', isType(refract, TYPES.ENUM));
+}
+
+export function selectType(refract) {
+  setCache(refract, 'isSelect', isType(refract, TYPES.SELECT));
+}
+
+export function objectType(refract) {
+  setCache(refract, 'isObject', isType(refract, TYPES.OBJECT));
+}
+
+export function included(refract) {
+  const results = sift(includedMember.query, [refract]);
+  const isIncluded = results.length > 0;
+
+  setCache(refract, 'isIncluded', isIncluded);
+}
+
+export function inherited(refract) {
+  const results = sift(inheritedMember.query, [refract]);
+  const isInherited = results.length > 0;
+
+  setCache(refract, 'isInherited', isInherited);
+}
+
+// Note: this check depends on the type checks above to have
+// been run first!
+export function structured(refract) {
+  const isStructured =
+    refract.cache.isObject || refract.cache.isArray ||
+    refract.cache.isEnum || refract.cache.isSelect;
+  setCache(refract, 'isStructured', isStructured);
+}
+
+export function referenced(refract) {
+  let isReferenced = false;
+
+  if (refract && refract.content && refract.content.value) {
+    const nestedElement = refract.content.value;
+
+    if (!isEmpty(nestedElement.content)) {
+      let ref;
+
+      isReferenced = every(nestedElement.content, (childElement) => {
+        if (!childElement.meta || !childElement.meta.ref) {
+          return false;
+        }
+
+        if (!ref) {
+          ref = childElement.meta.ref;
+          return true;
+        }
+
+        return childElement.meta.ref === ref;
+      });
+    }
+  }
+
+  setCache(refract, 'isReferenced', isReferenced);
+}

--- a/src/Preprocessor/is.js
+++ b/src/Preprocessor/is.js
@@ -3,31 +3,31 @@ import isEmpty from 'lodash/isEmpty';
 import sift from 'sift';
 import TYPES from '../types';
 
-import {QUERIES} from '../queries';
-import {setCache} from './utilities';
+import { QUERIES } from '../queries';
+import { setCache } from './utilities';
 
-const {includedMember, inheritedMember} = QUERIES;
+const { includedMember, inheritedMember } = QUERIES;
 
 function isType(refract, type) {
-  let isType = false;
+  let result = false;
 
   if (refract) {
     if (refract === type) {
-      isType = true;
+      result = true;
     }
 
     if (refract.element === type) {
-      isType = true;
+      result = true;
     } else if (refract.element === 'member') {
       // This is a member of an object, so we really care about the
       // type of its value, e.g. `string` rather than `member`.
       if (refract.content && refract.content.value && refract.content.value.element === type) {
-        isType = true;
+        result = true;
       }
     }
   }
 
-  return isType;
+  return result;
 }
 
 export function arrayType(refract) {

--- a/src/Preprocessor/test/preprocessor.js
+++ b/src/Preprocessor/test/preprocessor.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import {preprocess} from '../Preprocessor';
+import {preprocess, Preprocessor} from '../Preprocessor';
 
 describe('Preprocessor', () => {
   context('cache.hasDefault', () => {
@@ -386,6 +386,97 @@ describe('Preprocessor', () => {
       };
       const processed = preprocess(refract);
       assert.equal(processed.cache.containsStructuredElement, false);
+    });
+  });
+
+  context('sorting inherited members', () => {
+    const refract = {
+      element: 'object',
+      content: [
+        {
+          element: 'member',
+          content: {
+            key: {
+              element: 'string',
+              content: 'normal-1',
+            },
+          }
+        },
+        {
+          element: 'member',
+          meta: {
+            links: [
+              {
+                relation: 'origin',
+                href: 'http://refract.link/inherited-member/',
+              }
+            ]
+          },
+          content: {
+            key: {
+              element: 'string',
+              content: 'inherited-1',
+            },
+          }
+        },
+        {
+          element: 'member',
+          content: {
+            key: {
+              element: 'string',
+              content: 'normal-2',
+            },
+          }
+        },
+        {
+          element: 'member',
+          meta: {
+            links: [
+              {
+                relation: 'origin',
+                href: 'http://refract.link/inherited-member/',
+              }
+            ]
+          },
+          content: {
+            key: {
+              element: 'string',
+              content: 'inherited-2',
+            },
+          }
+        },
+      ]
+    };
+
+    const processedFirst = new Preprocessor(refract)
+      .process()
+      .sortInherited(true)
+      .value();
+    const keysFirst = processedFirst.content.map(
+      (element) => element.content.key.content);
+    const processedLast = new Preprocessor(refract)
+      .process()
+      .sortInherited(false)
+      .value();
+    const keysLast = processedLast.content.map(
+      (element) => element.content.key.content);
+
+    it('can sort inherited members first', () => {
+      assert.deepEqual(keysFirst, [
+        'inherited-1',
+        'inherited-2',
+        'normal-1',
+        'normal-2',
+      ]);
+    });
+
+    it('can sort inherited members last', () => {
+      assert.deepEqual(keysLast, [
+        'normal-1',
+        'normal-2',
+        'inherited-1',
+        'inherited-2',
+      ]);
     });
   });
 });

--- a/src/Preprocessor/test/preprocessor.js
+++ b/src/Preprocessor/test/preprocessor.js
@@ -1,0 +1,391 @@
+import assert from 'assert';
+import {preprocess} from '../Preprocessor';
+
+describe('Preprocessor', () => {
+  context('cache.hasDefault', () => {
+    it('is true if default is present', () => {
+      const refract = {
+        element: 'string',
+        attributes: {
+          default: 'hello, world!',
+        },
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.hasDefault, true);
+    });
+
+    it('is true if default is falsey', () => {
+      const refract = {
+        element: 'boolean',
+        attributes: {
+          default: false,
+        },
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.hasDefault, true);
+    });
+
+    it('is false if default is missing', () => {
+      const refract = {
+        element: 'string',
+        content: 'test',
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.hasDefault, false);
+    });
+  });
+
+  context('cache.hasSamples', () => {
+    it('is true if samples are present', () => {
+      const refract = {
+        element: 'string',
+        attributes: {
+          samples: ['hello', 'world'],
+        },
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.hasSamples, true);
+    });
+
+    it('is false if samples key is present but empty', () => {
+      const refract = {
+        element: 'string',
+        attributes: {
+          samples: [],
+        },
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.hasSamples, false);
+    });
+
+    it('is false if samples key is present but not array', () => {
+      const refract = {
+        element: 'string',
+        attributes: {
+          samples: null,
+        },
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.hasSamples, false);
+    });
+
+    it('is false if samples key is missing', () => {
+      const refract = {
+        element: 'string',
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.hasSamples, false);
+    });
+  });
+
+  context('cache.hasDescription', () => {
+    it('is true if description is present', () => {
+      const refract = {
+        element: 'string',
+        meta: {
+          description: 'hello',
+        }
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.hasDescription, true);
+    });
+
+    it('is false if description is empty', () => {
+      const refract = {
+        element: 'string',
+        meta: {
+          description: '',
+        }
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.hasDescription, false);
+    });
+
+    it('is false if description is missing', () => {
+      const refract = {
+        element: 'string',
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.hasDescription, false);
+    });
+  });
+
+  ['array', 'enum', 'select', 'object'].forEach((element) => {
+    const property = `is${element.charAt(0).toUpperCase() + element.slice(1)}`
+    context(`cache.${property}`, () => {
+      it(`is true if element is ${element}`, () => {
+        const refract = {
+          element: element,
+        };
+        const processed = preprocess(refract);
+        assert.equal(processed.cache[property], true);
+      });
+
+      it(`is true if member element value type is ${element}`, () => {
+        const refract = {
+          element: 'member',
+          content: {
+            key: {
+              element: 'string',
+              content: 'foo',
+            },
+            value: {
+              element: element,
+            },
+          },
+        };
+        const processed = preprocess(refract);
+        assert.equal(processed.cache[property], true);
+      });
+
+      it(`is false if element is not ${element}`, () => {
+        const refract = {
+          element: 'boolean',
+        };
+        const processed = preprocess(refract);
+        assert.equal(processed.cache[property], false);
+      });
+    });
+  });
+
+  context('cache.isIncluded', () => {
+    it('is true if link relation is present', () => {
+      const refract = {
+        element: 'string',
+        meta: {
+          links: [
+            {
+              relation: 'origin',
+              href: 'http://refract.link/included-member/',
+            }
+          ]
+        }
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.isIncluded, true);
+    });
+
+    it('is false if link relation is not a match', () => {
+      const refract = {
+        element: 'string',
+        meta: {
+          links: [
+            {
+              relation: 'origin',
+              href: 'http://refract.link/other/',
+            }
+          ]
+        }
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.isIncluded, false);
+    });
+
+    it('is false if link relation is missing', () => {
+      const refract = {
+        element: 'string',
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.isIncluded, false);
+    });
+  });
+
+  context('cache.isInherited', () => {
+    it('is true if link relation is present', () => {
+      const refract = {
+        element: 'string',
+        meta: {
+          links: [
+            {
+              relation: 'origin',
+              href: 'http://refract.link/inherited-member/',
+            }
+          ]
+        }
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.isInherited, true);
+    });
+
+    it('is false if link relation is not a match', () => {
+      const refract = {
+        element: 'string',
+        meta: {
+          links: [
+            {
+              relation: 'origin',
+              href: 'http://refract.link/other/',
+            }
+          ]
+        }
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.isInherited, false);
+    });
+
+    it('is false if link relation is missing', () => {
+      const refract = {
+        element: 'string',
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.isInherited, false);
+    });
+  });
+
+  context('cache.isStructured', () => {
+    it('is true if the type is object', () => {
+      const refract = {
+        element: 'object',
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.isStructured, true);
+    });
+    it('is true if the type is array', () => {
+      const refract = {
+        element: 'array',
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.isStructured, true);
+    });
+    it('is true if the type is enum', () => {
+      const refract = {
+        element: 'enum',
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.isStructured, true);
+    });
+    it('is true if the type is select', () => {
+      const refract = {
+        element: 'select',
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.isStructured, true);
+    });
+    it('is true if the type is member with the value type object', () => {
+      const refract = {
+        element: 'member',
+        content: {
+          value: {
+            element: 'object',
+          },
+        },
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.isStructured, true);
+    });
+    it('is false if the type is boolean', () => {
+      const refract = {
+        element: 'boolean',
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.isStructured, false);
+    });
+  });
+
+  context('cache.isReferenced', () => {
+    it('is true if all children have meta.ref', () => {
+      const refract = {
+        element: 'member',
+        content: {
+          value: {
+            element: 'object',
+            content: [
+              {
+                element: 'member',
+                meta: {
+                  ref: 'MyBase',
+                },
+              },
+            ],
+          },
+        },
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.isReferenced, true);
+    });
+
+    it('is false if only some children have meta.ref', () => {
+      const refract = {
+        element: 'member',
+        content: {
+          value: {
+            element: 'object',
+            content: [
+              {
+                element: 'member',
+                meta: {
+                  ref: 'MyBase',
+                },
+              },
+              {
+                element: 'member',
+              },
+            ],
+          },
+        },
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.isReferenced, false);
+    });
+
+    it('is false if there are no children', () => {
+      const refract = {
+        element: 'member',
+        content: {
+          value: {
+            element: 'string',
+          },
+        },
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.isReferenced, false);
+    });
+
+    it('is false if type is not member', () => {
+      const refract = {
+        element: 'boolean',
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.isReferenced, false);
+    });
+  });
+
+  context('cache.containsStructuredElement', () => {
+    it('is true if a child is structured', () => {
+      const refract = {
+        element: 'array',
+        content: [
+          {
+            element: 'object',
+          }
+        ],
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.containsStructuredElement, true);
+    });
+
+    it('is false if no child is structured', () => {
+      const refract = {
+        element: 'array',
+        content: [
+          {
+            element: 'boolean',
+          },
+          {
+            element: 'number',
+          },
+        ],
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.containsStructuredElement, false);
+    });
+
+    it('is false if there are no children', () => {
+      const refract = {
+        element: 'array',
+      };
+      const processed = preprocess(refract);
+      assert.equal(processed.cache.containsStructuredElement, false);
+    });
+  });
+});

--- a/src/Preprocessor/test/preprocessor.js
+++ b/src/Preprocessor/test/preprocessor.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import {preprocess, Preprocessor} from '../Preprocessor';
+import { preprocess, Preprocessor } from '../Preprocessor';
 
 describe('Preprocessor', () => {
   context('cache.hasDefault', () => {
@@ -84,7 +84,7 @@ describe('Preprocessor', () => {
         element: 'string',
         meta: {
           description: 'hello',
-        }
+        },
       };
       const processed = preprocess(refract);
       assert.equal(processed.cache.hasDescription, true);
@@ -95,7 +95,7 @@ describe('Preprocessor', () => {
         element: 'string',
         meta: {
           description: '',
-        }
+        },
       };
       const processed = preprocess(refract);
       assert.equal(processed.cache.hasDescription, false);
@@ -111,12 +111,10 @@ describe('Preprocessor', () => {
   });
 
   ['array', 'enum', 'select', 'object'].forEach((element) => {
-    const property = `is${element.charAt(0).toUpperCase() + element.slice(1)}`
+    const property = `is${element.charAt(0).toUpperCase() + element.slice(1)}`;
     context(`cache.${property}`, () => {
       it(`is true if element is ${element}`, () => {
-        const refract = {
-          element: element,
-        };
+        const refract = { element };
         const processed = preprocess(refract);
         assert.equal(processed.cache[property], true);
       });
@@ -129,9 +127,7 @@ describe('Preprocessor', () => {
               element: 'string',
               content: 'foo',
             },
-            value: {
-              element: element,
-            },
+            value: { element },
           },
         };
         const processed = preprocess(refract);
@@ -157,9 +153,9 @@ describe('Preprocessor', () => {
             {
               relation: 'origin',
               href: 'http://refract.link/included-member/',
-            }
-          ]
-        }
+            },
+          ],
+        },
       };
       const processed = preprocess(refract);
       assert.equal(processed.cache.isIncluded, true);
@@ -173,9 +169,9 @@ describe('Preprocessor', () => {
             {
               relation: 'origin',
               href: 'http://refract.link/other/',
-            }
-          ]
-        }
+            },
+          ],
+        },
       };
       const processed = preprocess(refract);
       assert.equal(processed.cache.isIncluded, false);
@@ -199,9 +195,9 @@ describe('Preprocessor', () => {
             {
               relation: 'origin',
               href: 'http://refract.link/inherited-member/',
-            }
-          ]
-        }
+            },
+          ],
+        },
       };
       const processed = preprocess(refract);
       assert.equal(processed.cache.isInherited, true);
@@ -215,9 +211,9 @@ describe('Preprocessor', () => {
             {
               relation: 'origin',
               href: 'http://refract.link/other/',
-            }
-          ]
-        }
+            },
+          ],
+        },
       };
       const processed = preprocess(refract);
       assert.equal(processed.cache.isInherited, false);
@@ -357,7 +353,7 @@ describe('Preprocessor', () => {
         content: [
           {
             element: 'object',
-          }
+          },
         ],
       };
       const processed = preprocess(refract);
@@ -400,7 +396,7 @@ describe('Preprocessor', () => {
               element: 'string',
               content: 'normal-1',
             },
-          }
+          },
         },
         {
           element: 'member',
@@ -409,15 +405,15 @@ describe('Preprocessor', () => {
               {
                 relation: 'origin',
                 href: 'http://refract.link/inherited-member/',
-              }
-            ]
+              },
+            ],
           },
           content: {
             key: {
               element: 'string',
               content: 'inherited-1',
             },
-          }
+          },
         },
         {
           element: 'member',
@@ -426,7 +422,7 @@ describe('Preprocessor', () => {
               element: 'string',
               content: 'normal-2',
             },
-          }
+          },
         },
         {
           element: 'member',
@@ -435,17 +431,17 @@ describe('Preprocessor', () => {
               {
                 relation: 'origin',
                 href: 'http://refract.link/inherited-member/',
-              }
-            ]
+              },
+            ],
           },
           content: {
             key: {
               element: 'string',
               content: 'inherited-2',
             },
-          }
+          },
         },
-      ]
+      ],
     };
 
     const processedFirst = new Preprocessor(refract)

--- a/src/Preprocessor/utilities.js
+++ b/src/Preprocessor/utilities.js
@@ -1,0 +1,11 @@
+/*
+ * Preprocessor utility functions.
+ */
+
+export function setCache(refract, name, value) {
+  if (refract.cache === undefined) {
+    refract.cache = {};
+  }
+
+  refract.cache[name] = value;
+}


### PR DESCRIPTION
This implements the refract tree preprocessor (#236) to help simplify and speed rendering of element react components.

* [x] Migrate existing functions into library
* [x] Write unit tests and fix any issues
* [x] Write sorting functions for inherited members
* [x] Make attributes component preprocess refract before other components try to render
* [ ] Switch react components to use `cache` information
* [ ] Remove leftover existing functions that are no longer needed

cc @Baggz 