### PR TITLE
Render number and boolean examples

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,8 +2,8 @@
 
 |                | NPM             | [Apiary](https://apiary.io) |
 |:---------------|:----------------|:----------------------------|
-| Stable Channel | `0.17.0`        | `0.18.0-beta.8`             |
-| Beta Channel   | `0.18.0-beta.8` | `0.18.0-beta.8`             |
+| Stable Channel | `0.17.0`        | `0.18.0-beta.9`             |
+| Beta Channel   | `0.18.0-beta.9` | `0.18.0-beta.9`             |
 
 This table indicates what's the _latest version of the Attributes Kit available in the NPM Registry_ and what's the _latest version that has been deployed_ to [Apiary](https://apiary.io).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attributes-kit",
-  "version": "0.18.0-beta.8",
+  "version": "0.18.0-beta.9",
   "description": "React component for MSON rendering",
   "engines": {
     "node": "5.7.x",

--- a/playground/parseMson.js
+++ b/playground/parseMson.js
@@ -1,3 +1,4 @@
+import isArray from 'lodash/isArray';
 import protagonist from 'protagonist';
 
 export default function parseMson(mson, cb) {
@@ -16,6 +17,10 @@ export default function parseMson(mson, cb) {
       parseResult.content[0].content[0].content
     ) {
       dataStructureElements = parseResult.content[0].content[0].content;
+    }
+
+    if (!isArray(dataStructureElements)) {
+      return cb(null, []);
     }
 
     dataStructureElements = dataStructureElements.map((element) =>

--- a/src/Components/Value/Value.js
+++ b/src/Components/Value/Value.js
@@ -44,16 +44,12 @@ class Value extends React.Component {
         );
       }
 
-      if (isString(this.props.element.content.value.content)) {
-        return (
-          <PrimitiveValue
-            value={this.props.element.content.value.content}
-            style={this.props.style}
-          />
-        );
-      }
-
-      return null;
+      return (
+        <PrimitiveValue
+          value={this.props.element.content.value.content}
+          style={this.props.style}
+        />
+      );
     }
 
     if (isStructured(this.props.element)) {

--- a/src/Components/Value/Value.js
+++ b/src/Components/Value/Value.js
@@ -1,7 +1,6 @@
 import isUndefined from 'lodash/isUndefined';
 
 import React from 'react';
-import isString from 'lodash/isString';
 
 import {
   isArray,

--- a/src/Modules/ElementUtils/test/value.js
+++ b/src/Modules/ElementUtils/test/value.js
@@ -1,0 +1,127 @@
+import assert from 'assert';
+
+import { hasValue } from '../value.js';
+
+describe('#hasValue', () => {
+  context('Element is not defined', () => {
+    it('It returns false', () => {
+      assert.strictEqual(
+        hasValue(undefined),
+        false
+      );
+    });
+  });
+
+  context('Element is an object', () => {
+    it('It returns false', () => {
+      assert.strictEqual(
+        hasValue({
+          cache: {
+            isObject: true,
+          },
+          element: 'object',
+          content: [],
+        }),
+        false
+      );
+    });
+  });
+
+  context('Element is an array', () => {
+    it('It returns false', () => {
+      assert.strictEqual(
+        hasValue({
+          cache: {
+            isArray: true,
+          },
+          element: 'array',
+          content: [],
+        }),
+        false
+      );
+    });
+  });
+
+  context('Content is set to ‘false’', () => {
+    it('It returns true', () => {
+      assert.strictEqual(
+        hasValue({
+          cache: {},
+          content: false,
+        }),
+        true
+      );
+    });
+  });
+
+  context('Content is set to ‘0’', () => {
+    it('It returns true', () => {
+      assert.strictEqual(
+        hasValue({
+          cache: {},
+          content: 0,
+        }),
+        true
+      );
+    });
+  });
+
+  context('Element is a member', () => {
+    context('Content is set to ‘false’', () => {
+      it('It returns true', () => {
+        assert.strictEqual(
+          hasValue({
+            cache: {},
+            element: 'member',
+            content: {
+              value: {
+                cache: {},
+                element: 'boolean',
+                content: false,
+              },
+            },
+          }),
+          true
+        );
+      });
+    });
+
+    context('Content is set to ‘0’', () => {
+      it('It returns true', () => {
+        assert.strictEqual(
+          hasValue({
+            cache: {},
+            element: 'member',
+            content: {
+              value: {
+                cache: {},
+                element: 'number',
+                content: 0,
+              },
+            },
+          }),
+          true
+        );
+      });
+    });
+
+    context('Content is set to a number', () => {
+      it('It returns true', () => {
+        assert.strictEqual(
+          hasValue({
+            cache: {},
+            element: 'member',
+            content: {
+              value: {
+                cache: {},
+                element: 'number',
+                content: 123,
+              },
+            },
+          }),
+          true
+        );
+      });
+    });
+  });
+});

--- a/src/Modules/ElementUtils/value.js
+++ b/src/Modules/ElementUtils/value.js
@@ -16,11 +16,11 @@ function hasValue(element) {
   }
 
   if (isMember(element.element)) {
-    if (element.content.value && isObjectOrArray(element.content.value)) {
+    if (!isUndefined(element.content.value) && isObjectOrArray(element.content.value)) {
       return false;
     }
 
-    if (!element.content.value.content) {
+    if (isUndefined(element.content.value.content)) {
       return false;
     }
   }


### PR DESCRIPTION
Previously examples of numbers (e.g. `+ id: 123456`) were not rendered correctly; this PR fixes the bug.