### PR TITLE
Use a better source for "externals" object in server build

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,8 @@
     "superagent": "^1.3.0",
     "svgo": "0.6.1",
     "webpack": "^1.12.13",
-    "webpack-dev-server": "1.14.1"
+    "webpack-dev-server": "1.14.1",
+    "webpack-node-externals": "^1.2.0"
   },
   "babel": {
     "presets": [

--- a/webpack/server.js
+++ b/webpack/server.js
@@ -1,18 +1,9 @@
 import merge from 'lodash/merge';
 import path from 'path';
-import fs from 'fs';
+import nodeExternals from 'webpack-node-externals';
 import webpack from 'webpack';
 
 import webpackConfig from './base';
-
-let nodeModules = {};
-fs.readdirSync('node_modules')
-  .filter((x) => {
-    return ['.bin'].indexOf(x) === -1;
-  })
-  .forEach((mod) => {
-    nodeModules[mod] = 'commonjs ' + mod;
-  });
 
 export default merge({}, webpackConfig, {
   target: 'node',
@@ -24,7 +15,7 @@ export default merge({}, webpackConfig, {
   entry: {
     'attributes-kit-server': path.join(__dirname, '../src/index'),
   },
-  externals: nodeModules,
+  externals: [nodeExternals()],
   plugins: [
     new webpack.NormalModuleReplacementPlugin(/\.(svg|css|styl)$/, 'node-noop'),
     new webpack.IgnorePlugin(/\.(svg|css|styl)$/)


### PR DESCRIPTION
The following PR will replace our home made system to detect external libraries for server build and replace it with a more consolidated library which contains more use cases.

This has been back ported from UiKit.