### PR TITLE
Performance update by removing global styles from description

### DIFF
--- a/fixtures/0001-primitive-type-boolean.md
+++ b/fixtures/0001-primitive-type-boolean.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Boolean</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
         data-radium="true">
         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-bottom:8px;padding-left:0px;padding-top:4px;">

--- a/fixtures/0002-primitive-type-boolean-with-description.md
+++ b/fixtures/0002-primitive-type-boolean-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Boolean</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
         data-radium="true">
         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-bottom:8px;padding-left:0px;padding-top:4px;">
@@ -9,34 +37,6 @@
         </div>
         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
             <div data-radium="true">
-                <style>
-                    .attributesKit p {
-                        margin-bottom: 4px;
-                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                        font-size: 14px;
-                        color: #8A93A3;
-                        line-height: 21px;
-                        font-weight: regular;
-                    }
-
-                    .attributesKit p:last-child {
-                        margin-bottom: 0px;
-                    }
-
-                    .attributesKit ul {
-                        margin-left: 20px;
-                    }
-
-                    .attributesKit a {
-                        color: #747E8E;
-                        text-decoration: none;
-                        border-bottom: 1px solid #DCE0E8;
-                    }
-
-                    .attributesKit a:hover {
-                        border-bottom: none;
-                    }
-                </style>
                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tincidunt auctor erat nec vulputate. Donec ut urna urna. Phasellus nisl dolor, posuere non placerat a, efficitur nec elit.</p>
                 </div>

--- a/fixtures/0003-primitive-type-boolean-with-block-description.md
+++ b/fixtures/0003-primitive-type-boolean-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Boolean</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
         data-radium="true">
         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-bottom:8px;padding-left:0px;padding-top:4px;">
@@ -9,34 +37,6 @@
         </div>
         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
             <div data-radium="true">
-                <style>
-                    .attributesKit p {
-                        margin-bottom: 4px;
-                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                        font-size: 14px;
-                        color: #8A93A3;
-                        line-height: 21px;
-                        font-weight: regular;
-                    }
-
-                    .attributesKit p:last-child {
-                        margin-bottom: 0px;
-                    }
-
-                    .attributesKit ul {
-                        margin-left: 20px;
-                    }
-
-                    .attributesKit a {
-                        color: #747E8E;
-                        text-decoration: none;
-                        border-bottom: 1px solid #DCE0E8;
-                    }
-
-                    .attributesKit a:hover {
-                        border-bottom: none;
-                    }
-                </style>
                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tincidunt auctor erat nec vulputate. Donec ut urna urna. Phasellus nisl dolor, posuere non placerat a, efficitur nec elit. Cras mattis nulla et volutpat ullamcorper.</p>
                     <p>Donec posuere ipsum at est egestas tempus. Nullam sed interdum eros. Proin accumsan sodales sodales. Nam consequat convallis augue vitae pretium. Maecenas quis orci fringilla ex interdum vestibulum non sed odio.</p>

--- a/fixtures/0004-primitive-type-number.md
+++ b/fixtures/0004-primitive-type-number.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Number</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
         data-radium="true">
         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-bottom:8px;padding-left:0px;padding-top:4px;">

--- a/fixtures/0005-primitive-type-number-with-description.md
+++ b/fixtures/0005-primitive-type-number-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Number</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
         data-radium="true">
         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-bottom:8px;padding-left:0px;padding-top:4px;">
@@ -9,34 +37,6 @@
         </div>
         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
             <div data-radium="true">
-                <style>
-                    .attributesKit p {
-                        margin-bottom: 4px;
-                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                        font-size: 14px;
-                        color: #8A93A3;
-                        line-height: 21px;
-                        font-weight: regular;
-                    }
-
-                    .attributesKit p:last-child {
-                        margin-bottom: 0px;
-                    }
-
-                    .attributesKit ul {
-                        margin-left: 20px;
-                    }
-
-                    .attributesKit a {
-                        color: #747E8E;
-                        text-decoration: none;
-                        border-bottom: 1px solid #DCE0E8;
-                    }
-
-                    .attributesKit a:hover {
-                        border-bottom: none;
-                    }
-                </style>
                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tincidunt auctor erat nec vulputate. Donec ut urna urna. Phasellus nisl dolor, posuere non placerat a, efficitur nec elit.</p>
                 </div>

--- a/fixtures/0006-primitive-type-number-with-block-description.md
+++ b/fixtures/0006-primitive-type-number-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Number</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
         data-radium="true">
         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-bottom:8px;padding-left:0px;padding-top:4px;">
@@ -9,34 +37,6 @@
         </div>
         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
             <div data-radium="true">
-                <style>
-                    .attributesKit p {
-                        margin-bottom: 4px;
-                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                        font-size: 14px;
-                        color: #8A93A3;
-                        line-height: 21px;
-                        font-weight: regular;
-                    }
-
-                    .attributesKit p:last-child {
-                        margin-bottom: 0px;
-                    }
-
-                    .attributesKit ul {
-                        margin-left: 20px;
-                    }
-
-                    .attributesKit a {
-                        color: #747E8E;
-                        text-decoration: none;
-                        border-bottom: 1px solid #DCE0E8;
-                    }
-
-                    .attributesKit a:hover {
-                        border-bottom: none;
-                    }
-                </style>
                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tincidunt auctor erat nec vulputate. Donec ut urna urna. Phasellus nisl dolor, posuere non placerat a, efficitur nec elit. Cras mattis nulla et volutpat ullamcorper.</p>
                     <p>Donec posuere ipsum at est egestas tempus. Nullam sed interdum eros. Proin accumsan sodales sodales. Nam consequat convallis augue vitae pretium. Maecenas quis orci fringilla ex interdum vestibulum non sed odio.</p>

--- a/fixtures/0007-primitive-type-string.md
+++ b/fixtures/0007-primitive-type-string.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My String</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
         data-radium="true">
         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-bottom:8px;padding-left:0px;padding-top:4px;">

--- a/fixtures/0008-primitive-type-string-with-description.md
+++ b/fixtures/0008-primitive-type-string-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My String</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
         data-radium="true">
         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-bottom:8px;padding-left:0px;padding-top:4px;">
@@ -9,34 +37,6 @@
         </div>
         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
             <div data-radium="true">
-                <style>
-                    .attributesKit p {
-                        margin-bottom: 4px;
-                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                        font-size: 14px;
-                        color: #8A93A3;
-                        line-height: 21px;
-                        font-weight: regular;
-                    }
-
-                    .attributesKit p:last-child {
-                        margin-bottom: 0px;
-                    }
-
-                    .attributesKit ul {
-                        margin-left: 20px;
-                    }
-
-                    .attributesKit a {
-                        color: #747E8E;
-                        text-decoration: none;
-                        border-bottom: 1px solid #DCE0E8;
-                    }
-
-                    .attributesKit a:hover {
-                        border-bottom: none;
-                    }
-                </style>
                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tincidunt auctor erat nec vulputate. Donec ut urna urna. Phasellus nisl dolor, posuere non placerat a, efficitur nec elit.</p>
                 </div>

--- a/fixtures/0009-primitive-type-string-with-block-description.md
+++ b/fixtures/0009-primitive-type-string-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My String</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
         data-radium="true">
         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-bottom:1px solid #E8EBEE;padding-bottom:8px;padding-left:0px;padding-top:4px;">
@@ -9,34 +37,6 @@
         </div>
         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
             <div data-radium="true">
-                <style>
-                    .attributesKit p {
-                        margin-bottom: 4px;
-                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                        font-size: 14px;
-                        color: #8A93A3;
-                        line-height: 21px;
-                        font-weight: regular;
-                    }
-
-                    .attributesKit p:last-child {
-                        margin-bottom: 0px;
-                    }
-
-                    .attributesKit ul {
-                        margin-left: 20px;
-                    }
-
-                    .attributesKit a {
-                        color: #747E8E;
-                        text-decoration: none;
-                        border-bottom: 1px solid #DCE0E8;
-                    }
-
-                    .attributesKit a:hover {
-                        border-bottom: none;
-                    }
-                </style>
                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tincidunt auctor erat nec vulputate. Donec ut urna urna. Phasellus nisl dolor, posuere non placerat a, efficitur nec elit. Cras mattis nulla et volutpat ullamcorper.</p>
                     <p>Donec posuere ipsum at est egestas tempus. Nullam sed interdum eros. Proin accumsan sodales sodales. Nam consequat convallis augue vitae pretium. Maecenas quis orci fringilla ex interdum vestibulum non sed odio.</p>

--- a/fixtures/0010-array-without-values.md
+++ b/fixtures/0010-array-without-values.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0011-array-without-values-with-array-sample.md
+++ b/fixtures/0011-array-without-values-with-array-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0012-array-without-values-with-array-samples.md
+++ b/fixtures/0012-array-without-values-with-array-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0013-array-without-values-with-array-default.md
+++ b/fixtures/0013-array-without-values-with-array-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0014-array-without-values-with-array-description.md
+++ b/fixtures/0014-array-without-values-with-array-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0015-array-without-values-with-array-block-description.md
+++ b/fixtures/0015-array-without-values-with-array-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0016-array-of-primitive-type.md
+++ b/fixtures/0016-array-of-primitive-type.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0017-array-of-primitive-type-with-sample.md
+++ b/fixtures/0017-array-of-primitive-type-with-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0018-array-of-primitive-type-with-inline-sample.md
+++ b/fixtures/0018-array-of-primitive-type-with-inline-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0019-array-of-primitive-type-with-samples.md
+++ b/fixtures/0019-array-of-primitive-type-with-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0020-array-of-primitive-type-with-default.md
+++ b/fixtures/0020-array-of-primitive-type-with-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0021-array-of-primitive-type-with-description.md
+++ b/fixtures/0021-array-of-primitive-type-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -23,34 +51,6 @@
                         </div>
                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                             <div data-radium="true">
-                                <style>
-                                    .attributesKit p {
-                                        margin-bottom: 4px;
-                                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                        font-size: 14px;
-                                        color: #8A93A3;
-                                        line-height: 21px;
-                                        font-weight: regular;
-                                    }
-
-                                    .attributesKit p:last-child {
-                                        margin-bottom: 0px;
-                                    }
-
-                                    .attributesKit ul {
-                                        margin-left: 20px;
-                                    }
-
-                                    .attributesKit a {
-                                        color: #747E8E;
-                                        text-decoration: none;
-                                        border-bottom: 1px solid #DCE0E8;
-                                    }
-
-                                    .attributesKit a:hover {
-                                        border-bottom: none;
-                                    }
-                                </style>
                                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                                     <p>Lorem ipsum dolor isamet pidet quidu delime.</p>
                                 </div>

--- a/fixtures/0022-array-of-primitive-type-with-block-description.md
+++ b/fixtures/0022-array-of-primitive-type-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0023-array-of-primitive-type-with-array-description.md
+++ b/fixtures/0023-array-of-primitive-type-with-array-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0024-array-of-primitive-type-with-array-block-description.md
+++ b/fixtures/0024-array-of-primitive-type-with-array-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0025-array-of-primitive-type-with-array-sample.md
+++ b/fixtures/0025-array-of-primitive-type-with-array-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0026-array-of-primitive-type-with-array-samples.md
+++ b/fixtures/0026-array-of-primitive-type-with-array-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0027-array-of-primitive-type-with-array-default.md
+++ b/fixtures/0027-array-of-primitive-type-with-array-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0028-array-of-primitive-types.md
+++ b/fixtures/0028-array-of-primitive-types.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0029-array-of-primitive-types-with-array-sample.md
+++ b/fixtures/0029-array-of-primitive-types-with-array-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0030-array-of-primitive-types-with-array-samples.md
+++ b/fixtures/0030-array-of-primitive-types-with-array-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0031-array-of-primitive-types-with-array-default.md
+++ b/fixtures/0031-array-of-primitive-types-with-array-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0032-array-of-primitive-types-with-description.md
+++ b/fixtures/0032-array-of-primitive-types-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -23,34 +51,6 @@
                         </div>
                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                             <div data-radium="true">
-                                <style>
-                                    .attributesKit p {
-                                        margin-bottom: 4px;
-                                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                        font-size: 14px;
-                                        color: #8A93A3;
-                                        line-height: 21px;
-                                        font-weight: regular;
-                                    }
-
-                                    .attributesKit p:last-child {
-                                        margin-bottom: 0px;
-                                    }
-
-                                    .attributesKit ul {
-                                        margin-left: 20px;
-                                    }
-
-                                    .attributesKit a {
-                                        color: #747E8E;
-                                        text-decoration: none;
-                                        border-bottom: 1px solid #DCE0E8;
-                                    }
-
-                                    .attributesKit a:hover {
-                                        border-bottom: none;
-                                    }
-                                </style>
                                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                                     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
                                 </div>
@@ -74,34 +74,6 @@
                         </div>
                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                             <div data-radium="true">
-                                <style>
-                                    .attributesKit p {
-                                        margin-bottom: 4px;
-                                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                        font-size: 14px;
-                                        color: #8A93A3;
-                                        line-height: 21px;
-                                        font-weight: regular;
-                                    }
-
-                                    .attributesKit p:last-child {
-                                        margin-bottom: 0px;
-                                    }
-
-                                    .attributesKit ul {
-                                        margin-left: 20px;
-                                    }
-
-                                    .attributesKit a {
-                                        color: #747E8E;
-                                        text-decoration: none;
-                                        border-bottom: 1px solid #DCE0E8;
-                                    }
-
-                                    .attributesKit a:hover {
-                                        border-bottom: none;
-                                    }
-                                </style>
                                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                                     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
                                 </div>
@@ -125,34 +97,6 @@
                         </div>
                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                             <div data-radium="true">
-                                <style>
-                                    .attributesKit p {
-                                        margin-bottom: 4px;
-                                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                        font-size: 14px;
-                                        color: #8A93A3;
-                                        line-height: 21px;
-                                        font-weight: regular;
-                                    }
-
-                                    .attributesKit p:last-child {
-                                        margin-bottom: 0px;
-                                    }
-
-                                    .attributesKit ul {
-                                        margin-left: 20px;
-                                    }
-
-                                    .attributesKit a {
-                                        color: #747E8E;
-                                        text-decoration: none;
-                                        border-bottom: 1px solid #DCE0E8;
-                                    }
-
-                                    .attributesKit a:hover {
-                                        border-bottom: none;
-                                    }
-                                </style>
                                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                                     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
                                 </div>

--- a/fixtures/0033-array-of-primitive-types-with-block-description.md
+++ b/fixtures/0033-array-of-primitive-types-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0033a-array-of-primitive-types-without-values.md
+++ b/fixtures/0033a-array-of-primitive-types-without-values.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0033b-array-of-primitive-types-without-values-with-description.md
+++ b/fixtures/0033b-array-of-primitive-types-without-values-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -18,34 +46,6 @@
                         </div>
                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                             <div data-radium="true">
-                                <style>
-                                    .attributesKit p {
-                                        margin-bottom: 4px;
-                                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                        font-size: 14px;
-                                        color: #8A93A3;
-                                        line-height: 21px;
-                                        font-weight: regular;
-                                    }
-
-                                    .attributesKit p:last-child {
-                                        margin-bottom: 0px;
-                                    }
-
-                                    .attributesKit ul {
-                                        margin-left: 20px;
-                                    }
-
-                                    .attributesKit a {
-                                        color: #747E8E;
-                                        text-decoration: none;
-                                        border-bottom: 1px solid #DCE0E8;
-                                    }
-
-                                    .attributesKit a:hover {
-                                        border-bottom: none;
-                                    }
-                                </style>
                                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                                     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
                                 </div>
@@ -64,34 +64,6 @@
                         </div>
                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                             <div data-radium="true">
-                                <style>
-                                    .attributesKit p {
-                                        margin-bottom: 4px;
-                                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                        font-size: 14px;
-                                        color: #8A93A3;
-                                        line-height: 21px;
-                                        font-weight: regular;
-                                    }
-
-                                    .attributesKit p:last-child {
-                                        margin-bottom: 0px;
-                                    }
-
-                                    .attributesKit ul {
-                                        margin-left: 20px;
-                                    }
-
-                                    .attributesKit a {
-                                        color: #747E8E;
-                                        text-decoration: none;
-                                        border-bottom: 1px solid #DCE0E8;
-                                    }
-
-                                    .attributesKit a:hover {
-                                        border-bottom: none;
-                                    }
-                                </style>
                                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                                     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
                                 </div>
@@ -110,34 +82,6 @@
                         </div>
                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                             <div data-radium="true">
-                                <style>
-                                    .attributesKit p {
-                                        margin-bottom: 4px;
-                                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                        font-size: 14px;
-                                        color: #8A93A3;
-                                        line-height: 21px;
-                                        font-weight: regular;
-                                    }
-
-                                    .attributesKit p:last-child {
-                                        margin-bottom: 0px;
-                                    }
-
-                                    .attributesKit ul {
-                                        margin-left: 20px;
-                                    }
-
-                                    .attributesKit a {
-                                        color: #747E8E;
-                                        text-decoration: none;
-                                        border-bottom: 1px solid #DCE0E8;
-                                    }
-
-                                    .attributesKit a:hover {
-                                        border-bottom: none;
-                                    }
-                                </style>
                                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                                     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
                                 </div>

--- a/fixtures/0033c-array-of-primitive-types-without-values-with-block-description.md
+++ b/fixtures/0033c-array-of-primitive-types-without-values-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0033d-array-of-primitive-types-without-values-with-sample.md
+++ b/fixtures/0033d-array-of-primitive-types-without-values-with-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0033e-array-of-primitive-types-without-values-with-samples.md
+++ b/fixtures/0033e-array-of-primitive-types-without-values-with-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0033f-array-of-primitive-types-without-values-with-default.md
+++ b/fixtures/0033f-array-of-primitive-types-without-values-with-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0034-array-of-array-without-values.md
+++ b/fixtures/0034-array-of-array-without-values.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0035-array-of-array-without-values-with-description.md
+++ b/fixtures/0035-array-of-array-without-values-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -12,34 +40,6 @@
                         data-radium="true">
                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                             <div data-radium="true">
-                                <style>
-                                    .attributesKit p {
-                                        margin-bottom: 4px;
-                                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                        font-size: 14px;
-                                        color: #8A93A3;
-                                        line-height: 21px;
-                                        font-weight: regular;
-                                    }
-
-                                    .attributesKit p:last-child {
-                                        margin-bottom: 0px;
-                                    }
-
-                                    .attributesKit ul {
-                                        margin-left: 20px;
-                                    }
-
-                                    .attributesKit a {
-                                        color: #747E8E;
-                                        text-decoration: none;
-                                        border-bottom: 1px solid #DCE0E8;
-                                    }
-
-                                    .attributesKit a:hover {
-                                        border-bottom: none;
-                                    }
-                                </style>
                                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                                     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
                                 </div>

--- a/fixtures/0036-array-of-array-without-values-with-block-description.md
+++ b/fixtures/0036-array-of-array-without-values-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0037-array-of-array.md
+++ b/fixtures/0037-array-of-array.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0038-array-of-array-with-description.md
+++ b/fixtures/0038-array-of-array-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -12,34 +40,6 @@
                         data-radium="true">
                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                             <div data-radium="true">
-                                <style>
-                                    .attributesKit p {
-                                        margin-bottom: 4px;
-                                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                        font-size: 14px;
-                                        color: #8A93A3;
-                                        line-height: 21px;
-                                        font-weight: regular;
-                                    }
-
-                                    .attributesKit p:last-child {
-                                        margin-bottom: 0px;
-                                    }
-
-                                    .attributesKit ul {
-                                        margin-left: 20px;
-                                    }
-
-                                    .attributesKit a {
-                                        color: #747E8E;
-                                        text-decoration: none;
-                                        border-bottom: 1px solid #DCE0E8;
-                                    }
-
-                                    .attributesKit a:hover {
-                                        border-bottom: none;
-                                    }
-                                </style>
                                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                                     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
                                 </div>

--- a/fixtures/0039-array-of-array-with-block-description.md
+++ b/fixtures/0039-array-of-array-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0040-array-of-array-with-array-sample.md
+++ b/fixtures/0040-array-of-array-with-array-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0041-array-of-array-with-array-samples.md
+++ b/fixtures/0041-array-of-array-with-array-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0042-array-of-array-with-array-default.md
+++ b/fixtures/0042-array-of-array-with-array-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0043-array-of-enum-without-values.md
+++ b/fixtures/0043-array-of-enum-without-values.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0044-array-of-enum-without-values-with-description.md
+++ b/fixtures/0044-array-of-enum-without-values-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -12,34 +40,6 @@
                         data-radium="true">
                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                             <div data-radium="true">
-                                <style>
-                                    .attributesKit p {
-                                        margin-bottom: 4px;
-                                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                        font-size: 14px;
-                                        color: #8A93A3;
-                                        line-height: 21px;
-                                        font-weight: regular;
-                                    }
-
-                                    .attributesKit p:last-child {
-                                        margin-bottom: 0px;
-                                    }
-
-                                    .attributesKit ul {
-                                        margin-left: 20px;
-                                    }
-
-                                    .attributesKit a {
-                                        color: #747E8E;
-                                        text-decoration: none;
-                                        border-bottom: 1px solid #DCE0E8;
-                                    }
-
-                                    .attributesKit a:hover {
-                                        border-bottom: none;
-                                    }
-                                </style>
                                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                                     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt.</p>
                                 </div>

--- a/fixtures/0045-array-of-enum-without-values-with-block-description.md
+++ b/fixtures/0045-array-of-enum-without-values-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0046-array-of-enum.md
+++ b/fixtures/0046-array-of-enum.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0047-array-of-enum-with-description.md
+++ b/fixtures/0047-array-of-enum-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -12,34 +40,6 @@
                         data-radium="true">
                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                             <div data-radium="true">
-                                <style>
-                                    .attributesKit p {
-                                        margin-bottom: 4px;
-                                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                        font-size: 14px;
-                                        color: #8A93A3;
-                                        line-height: 21px;
-                                        font-weight: regular;
-                                    }
-
-                                    .attributesKit p:last-child {
-                                        margin-bottom: 0px;
-                                    }
-
-                                    .attributesKit ul {
-                                        margin-left: 20px;
-                                    }
-
-                                    .attributesKit a {
-                                        color: #747E8E;
-                                        text-decoration: none;
-                                        border-bottom: 1px solid #DCE0E8;
-                                    }
-
-                                    .attributesKit a:hover {
-                                        border-bottom: none;
-                                    }
-                                </style>
                                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                                     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt.</p>
                                 </div>

--- a/fixtures/0048-array-of-enum-with-block-description.md
+++ b/fixtures/0048-array-of-enum-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0049-array-of-enum-with-array-sample.md
+++ b/fixtures/0049-array-of-enum-with-array-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0050-array-of-enum-with-array-samples.md
+++ b/fixtures/0050-array-of-enum-with-array-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0051-array-of-enum-with-array-default.md
+++ b/fixtures/0051-array-of-enum-with-array-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0052-array-of-object-without-values.md
+++ b/fixtures/0052-array-of-object-without-values.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0053-array-of-object-without-values-with-description.md
+++ b/fixtures/0053-array-of-object-without-values-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0054-array-of-object-without-values-with-block-description.md
+++ b/fixtures/0054-array-of-object-without-values-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0055-array-of-object.md
+++ b/fixtures/0055-array-of-object.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0056-array-of-object-with-description.md
+++ b/fixtures/0056-array-of-object-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0057-array-of-object-with-block-description.md
+++ b/fixtures/0057-array-of-object-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0058-array-of-object-with-sample.md
+++ b/fixtures/0058-array-of-object-with-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0059-array-of-object-with-samples.md
+++ b/fixtures/0059-array-of-object-with-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0060-array-of-object-with-default.md
+++ b/fixtures/0060-array-of-object-with-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0061-array-of-object-with-array-sample.md
+++ b/fixtures/0061-array-of-object-with-array-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0062-array-of-object-with-array-samples.md
+++ b/fixtures/0062-array-of-object-with-array-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0063a-array-of-object-with-array-default.md
+++ b/fixtures/0063a-array-of-object-with-array-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0063b-array-of-mixed-primitive-types.md
+++ b/fixtures/0063b-array-of-mixed-primitive-types.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0063b-array-of-mixed-structure-types.md
+++ b/fixtures/0063b-array-of-mixed-structure-types.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0063b-array-of-mixed-types-only.md
+++ b/fixtures/0063b-array-of-mixed-types-only.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0063b-array-of-mixed-types.md
+++ b/fixtures/0063b-array-of-mixed-types.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0063b-array-of-structure-types-only.md
+++ b/fixtures/0063b-array-of-structure-types-only.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Array</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0064-object-without-values.md
+++ b/fixtures/0064-object-without-values.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0065-object-without-values-with-object-sample.md
+++ b/fixtures/0065-object-without-values-with-object-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0066-object-without-values-with-object-samples.md
+++ b/fixtures/0066-object-without-values-with-object-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0067-object-without-values-with-object-default.md
+++ b/fixtures/0067-object-without-values-with-object-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0068-object-without-values-with-description.md
+++ b/fixtures/0068-object-without-values-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0069-object-without-values-with-block-description.md
+++ b/fixtures/0069-object-without-values-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0070-object-of-primitive-type.md
+++ b/fixtures/0070-object-of-primitive-type.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0071-object-of-primitive-type-with-sample.md
+++ b/fixtures/0071-object-of-primitive-type-with-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0072-object-of-primitive-type-with-inline-sample.md
+++ b/fixtures/0072-object-of-primitive-type-with-inline-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0073-object-of-primitive-type-with-samples.md
+++ b/fixtures/0073-object-of-primitive-type-with-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0074-object-of-primitive-type-with-default.md
+++ b/fixtures/0074-object-of-primitive-type-with-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0075-object-of-primitive-type-with-description.md
+++ b/fixtures/0075-object-of-primitive-type-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -25,34 +53,6 @@
                                     </div>
                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                                         <div data-radium="true">
-                                            <style>
-                                                .attributesKit p {
-                                                    margin-bottom: 4px;
-                                                    font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                                    font-size: 14px;
-                                                    color: #8A93A3;
-                                                    line-height: 21px;
-                                                    font-weight: regular;
-                                                }
-
-                                                .attributesKit p:last-child {
-                                                    margin-bottom: 0px;
-                                                }
-
-                                                .attributesKit ul {
-                                                    margin-left: 20px;
-                                                }
-
-                                                .attributesKit a {
-                                                    color: #747E8E;
-                                                    text-decoration: none;
-                                                    border-bottom: 1px solid #DCE0E8;
-                                                }
-
-                                                .attributesKit a:hover {
-                                                    border-bottom: none;
-                                                }
-                                            </style>
                                             <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-top:6px;" data-radium="true">
                                                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
                                             </div>

--- a/fixtures/0076-object-of-primitive-type-with-block-description.md
+++ b/fixtures/0076-object-of-primitive-type-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -25,34 +53,6 @@
                                     </div>
                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                                         <div data-radium="true">
-                                            <style>
-                                                .attributesKit p {
-                                                    margin-bottom: 4px;
-                                                    font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                                    font-size: 14px;
-                                                    color: #8A93A3;
-                                                    line-height: 21px;
-                                                    font-weight: regular;
-                                                }
-
-                                                .attributesKit p:last-child {
-                                                    margin-bottom: 0px;
-                                                }
-
-                                                .attributesKit ul {
-                                                    margin-left: 20px;
-                                                }
-
-                                                .attributesKit a {
-                                                    color: #747E8E;
-                                                    text-decoration: none;
-                                                    border-bottom: 1px solid #DCE0E8;
-                                                }
-
-                                                .attributesKit a:hover {
-                                                    border-bottom: none;
-                                                }
-                                            </style>
                                             <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-top:6px;" data-radium="true">
                                                 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tincidunt auctor erat nec vulputate. Donec ut urna urna. Phasellus nisl dolor, posuere non placerat a, efficitur nec elit. Cras mattis nulla
                                                     et volutpat ullamcorper.</p>

--- a/fixtures/0077-object-of-primitive-type-with-object-sample.md
+++ b/fixtures/0077-object-of-primitive-type-with-object-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0078-object-of-primitive-type-with-object-samples.md
+++ b/fixtures/0078-object-of-primitive-type-with-object-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0079-object-of-primitive-type-with-object-default.md
+++ b/fixtures/0079-object-of-primitive-type-with-object-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0080a-object-of-primitive-types-without-values.md
+++ b/fixtures/0080a-object-of-primitive-types-without-values.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0080a1-object-of-primitive-types-without-values-with-description.md
+++ b/fixtures/0080a1-object-of-primitive-types-without-values-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -25,34 +53,6 @@
                                     </div>
                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                                         <div data-radium="true">
-                                            <style>
-                                                .attributesKit p {
-                                                    margin-bottom: 4px;
-                                                    font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                                    font-size: 14px;
-                                                    color: #8A93A3;
-                                                    line-height: 21px;
-                                                    font-weight: regular;
-                                                }
-
-                                                .attributesKit p:last-child {
-                                                    margin-bottom: 0px;
-                                                }
-
-                                                .attributesKit ul {
-                                                    margin-left: 20px;
-                                                }
-
-                                                .attributesKit a {
-                                                    color: #747E8E;
-                                                    text-decoration: none;
-                                                    border-bottom: 1px solid #DCE0E8;
-                                                }
-
-                                                .attributesKit a:hover {
-                                                    border-bottom: none;
-                                                }
-                                            </style>
                                             <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-top:6px;" data-radium="true">
                                                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
                                             </div>
@@ -75,34 +75,6 @@
                                     </div>
                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                                         <div data-radium="true">
-                                            <style>
-                                                .attributesKit p {
-                                                    margin-bottom: 4px;
-                                                    font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                                    font-size: 14px;
-                                                    color: #8A93A3;
-                                                    line-height: 21px;
-                                                    font-weight: regular;
-                                                }
-
-                                                .attributesKit p:last-child {
-                                                    margin-bottom: 0px;
-                                                }
-
-                                                .attributesKit ul {
-                                                    margin-left: 20px;
-                                                }
-
-                                                .attributesKit a {
-                                                    color: #747E8E;
-                                                    text-decoration: none;
-                                                    border-bottom: 1px solid #DCE0E8;
-                                                }
-
-                                                .attributesKit a:hover {
-                                                    border-bottom: none;
-                                                }
-                                            </style>
                                             <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-top:6px;" data-radium="true">
                                                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
                                             </div>

--- a/fixtures/0080a10-object-of-primitive-types-without-values-with-object-default.md
+++ b/fixtures/0080a10-object-of-primitive-types-without-values-with-object-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0080a2-object-of-primitive-types-without-values-with-block-description.md
+++ b/fixtures/0080a2-object-of-primitive-types-without-values-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -25,34 +53,6 @@
                                     </div>
                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                                         <div data-radium="true">
-                                            <style>
-                                                .attributesKit p {
-                                                    margin-bottom: 4px;
-                                                    font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                                    font-size: 14px;
-                                                    color: #8A93A3;
-                                                    line-height: 21px;
-                                                    font-weight: regular;
-                                                }
-
-                                                .attributesKit p:last-child {
-                                                    margin-bottom: 0px;
-                                                }
-
-                                                .attributesKit ul {
-                                                    margin-left: 20px;
-                                                }
-
-                                                .attributesKit a {
-                                                    color: #747E8E;
-                                                    text-decoration: none;
-                                                    border-bottom: 1px solid #DCE0E8;
-                                                }
-
-                                                .attributesKit a:hover {
-                                                    border-bottom: none;
-                                                }
-                                            </style>
                                             <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-top:6px;" data-radium="true">
                                                 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tincidunt auctor erat nec vulputate. Donec ut urna urna. Phasellus nisl dolor, posuere non placerat a, efficitur nec elit. Cras mattis nulla
                                                     et volutpat ullamcorper.</p>
@@ -101,34 +101,6 @@
                                     </div>
                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                                         <div data-radium="true">
-                                            <style>
-                                                .attributesKit p {
-                                                    margin-bottom: 4px;
-                                                    font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                                    font-size: 14px;
-                                                    color: #8A93A3;
-                                                    line-height: 21px;
-                                                    font-weight: regular;
-                                                }
-
-                                                .attributesKit p:last-child {
-                                                    margin-bottom: 0px;
-                                                }
-
-                                                .attributesKit ul {
-                                                    margin-left: 20px;
-                                                }
-
-                                                .attributesKit a {
-                                                    color: #747E8E;
-                                                    text-decoration: none;
-                                                    border-bottom: 1px solid #DCE0E8;
-                                                }
-
-                                                .attributesKit a:hover {
-                                                    border-bottom: none;
-                                                }
-                                            </style>
                                             <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-top:6px;" data-radium="true">
                                                 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tincidunt auctor erat nec vulputate. Donec ut urna urna. Phasellus nisl dolor, posuere non placerat a, efficitur nec elit. Cras mattis nulla
                                                     et volutpat ullamcorper.</p>

--- a/fixtures/0080a3-object-of-primitive-types-without-values-with-sample.md
+++ b/fixtures/0080a3-object-of-primitive-types-without-values-with-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0080a4-object-of-primitive-types-without-values-with-samples.md
+++ b/fixtures/0080a4-object-of-primitive-types-without-values-with-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0080a5-object-of-primitive-types-without-values-with-default.md
+++ b/fixtures/0080a5-object-of-primitive-types-without-values-with-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0080a6-object-of-primitive-types-without-values-with-object-description.md
+++ b/fixtures/0080a6-object-of-primitive-types-without-values-with-object-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0080a7-object-of-primitive-types-without-values-with-object-block-description.md
+++ b/fixtures/0080a7-object-of-primitive-types-without-values-with-object-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0080a8-object-of-primitive-types-without-values-with-object-sample.md
+++ b/fixtures/0080a8-object-of-primitive-types-without-values-with-object-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0080a9-object-of-primitive-types-without-values-with-object-samples.md
+++ b/fixtures/0080a9-object-of-primitive-types-without-values-with-object-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0081a-object-of-primitive-types.md
+++ b/fixtures/0081a-object-of-primitive-types.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0081b-object-of-primitive-types-with-sample.md
+++ b/fixtures/0081b-object-of-primitive-types-with-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0082-object-of-primitive-types-with-inline-sample.md
+++ b/fixtures/0082-object-of-primitive-types-with-inline-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0083-object-of-primitive-types-with-samples.md
+++ b/fixtures/0083-object-of-primitive-types-with-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0084-object-of-primitive-types-with-default.md
+++ b/fixtures/0084-object-of-primitive-types-with-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0085-object-of-primitive-types-with-description.md
+++ b/fixtures/0085-object-of-primitive-types-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -25,34 +53,6 @@
                                     </div>
                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                                         <div data-radium="true">
-                                            <style>
-                                                .attributesKit p {
-                                                    margin-bottom: 4px;
-                                                    font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                                    font-size: 14px;
-                                                    color: #8A93A3;
-                                                    line-height: 21px;
-                                                    font-weight: regular;
-                                                }
-
-                                                .attributesKit p:last-child {
-                                                    margin-bottom: 0px;
-                                                }
-
-                                                .attributesKit ul {
-                                                    margin-left: 20px;
-                                                }
-
-                                                .attributesKit a {
-                                                    color: #747E8E;
-                                                    text-decoration: none;
-                                                    border-bottom: 1px solid #DCE0E8;
-                                                }
-
-                                                .attributesKit a:hover {
-                                                    border-bottom: none;
-                                                }
-                                            </style>
                                             <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-top:6px;" data-radium="true">
                                                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
                                             </div>
@@ -79,34 +79,6 @@
                                     </div>
                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                                         <div data-radium="true">
-                                            <style>
-                                                .attributesKit p {
-                                                    margin-bottom: 4px;
-                                                    font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                                    font-size: 14px;
-                                                    color: #8A93A3;
-                                                    line-height: 21px;
-                                                    font-weight: regular;
-                                                }
-
-                                                .attributesKit p:last-child {
-                                                    margin-bottom: 0px;
-                                                }
-
-                                                .attributesKit ul {
-                                                    margin-left: 20px;
-                                                }
-
-                                                .attributesKit a {
-                                                    color: #747E8E;
-                                                    text-decoration: none;
-                                                    border-bottom: 1px solid #DCE0E8;
-                                                }
-
-                                                .attributesKit a:hover {
-                                                    border-bottom: none;
-                                                }
-                                            </style>
                                             <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-top:6px;" data-radium="true">
                                                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
                                             </div>

--- a/fixtures/0086a-object-of-primitive-types-with-block-description.md
+++ b/fixtures/0086a-object-of-primitive-types-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -25,34 +53,6 @@
                                     </div>
                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                                         <div data-radium="true">
-                                            <style>
-                                                .attributesKit p {
-                                                    margin-bottom: 4px;
-                                                    font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                                    font-size: 14px;
-                                                    color: #8A93A3;
-                                                    line-height: 21px;
-                                                    font-weight: regular;
-                                                }
-
-                                                .attributesKit p:last-child {
-                                                    margin-bottom: 0px;
-                                                }
-
-                                                .attributesKit ul {
-                                                    margin-left: 20px;
-                                                }
-
-                                                .attributesKit a {
-                                                    color: #747E8E;
-                                                    text-decoration: none;
-                                                    border-bottom: 1px solid #DCE0E8;
-                                                }
-
-                                                .attributesKit a:hover {
-                                                    border-bottom: none;
-                                                }
-                                            </style>
                                             <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-top:6px;" data-radium="true">
                                                 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tincidunt auctor erat nec vulputate. Donec ut urna urna. Phasellus nisl dolor, posuere non placerat a, efficitur nec elit. Cras mattis nulla
                                                     et volutpat ullamcorper.</p>
@@ -105,34 +105,6 @@
                                     </div>
                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                                         <div data-radium="true">
-                                            <style>
-                                                .attributesKit p {
-                                                    margin-bottom: 4px;
-                                                    font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                                    font-size: 14px;
-                                                    color: #8A93A3;
-                                                    line-height: 21px;
-                                                    font-weight: regular;
-                                                }
-
-                                                .attributesKit p:last-child {
-                                                    margin-bottom: 0px;
-                                                }
-
-                                                .attributesKit ul {
-                                                    margin-left: 20px;
-                                                }
-
-                                                .attributesKit a {
-                                                    color: #747E8E;
-                                                    text-decoration: none;
-                                                    border-bottom: 1px solid #DCE0E8;
-                                                }
-
-                                                .attributesKit a:hover {
-                                                    border-bottom: none;
-                                                }
-                                            </style>
                                             <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-top:6px;" data-radium="true">
                                                 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tincidunt auctor erat nec vulputate. Donec ut urna urna. Phasellus nisl dolor, posuere non placerat a, efficitur nec elit. Cras mattis nulla
                                                     et volutpat ullamcorper.</p>

--- a/fixtures/0086b-object-of-primitive-types-with-object-description.md
+++ b/fixtures/0086b-object-of-primitive-types-with-object-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0086c-object-of-primitive-types-with-object-block-description.md
+++ b/fixtures/0086c-object-of-primitive-types-with-object-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0087-object-of-primitive-types-with-object-sample.md
+++ b/fixtures/0087-object-of-primitive-types-with-object-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0088-object-of-primitive-types-with-object-samples.md
+++ b/fixtures/0088-object-of-primitive-types-with-object-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0089-object-of-primitive-types-with-object-default.md
+++ b/fixtures/0089-object-of-primitive-types-with-object-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0090a-object-of-array-without-values.md
+++ b/fixtures/0090a-object-of-array-without-values.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0090b-object-of-array.md
+++ b/fixtures/0090b-object-of-array.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0091-object-of-array-with-description.md
+++ b/fixtures/0091-object-of-array-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -51,34 +79,6 @@
                                                                     </div>
                                                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                                                                         <div data-radium="true">
-                                                                            <style>
-                                                                                .attributesKit p {
-                                                                                    margin-bottom: 4px;
-                                                                                    font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                                                                    font-size: 14px;
-                                                                                    color: #8A93A3;
-                                                                                    line-height: 21px;
-                                                                                    font-weight: regular;
-                                                                                }
-
-                                                                                .attributesKit p:last-child {
-                                                                                    margin-bottom: 0px;
-                                                                                }
-
-                                                                                .attributesKit ul {
-                                                                                    margin-left: 20px;
-                                                                                }
-
-                                                                                .attributesKit a {
-                                                                                    color: #747E8E;
-                                                                                    text-decoration: none;
-                                                                                    border-bottom: 1px solid #DCE0E8;
-                                                                                }
-
-                                                                                .attributesKit a:hover {
-                                                                                    border-bottom: none;
-                                                                                }
-                                                                            </style>
                                                                             <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                                                                                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.</p>
                                                                             </div>
@@ -102,34 +102,6 @@
                                                                     </div>
                                                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                                                                         <div data-radium="true">
-                                                                            <style>
-                                                                                .attributesKit p {
-                                                                                    margin-bottom: 4px;
-                                                                                    font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                                                                    font-size: 14px;
-                                                                                    color: #8A93A3;
-                                                                                    line-height: 21px;
-                                                                                    font-weight: regular;
-                                                                                }
-
-                                                                                .attributesKit p:last-child {
-                                                                                    margin-bottom: 0px;
-                                                                                }
-
-                                                                                .attributesKit ul {
-                                                                                    margin-left: 20px;
-                                                                                }
-
-                                                                                .attributesKit a {
-                                                                                    color: #747E8E;
-                                                                                    text-decoration: none;
-                                                                                    border-bottom: 1px solid #DCE0E8;
-                                                                                }
-
-                                                                                .attributesKit a:hover {
-                                                                                    border-bottom: none;
-                                                                                }
-                                                                            </style>
                                                                             <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                                                                                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.</p>
                                                                             </div>
@@ -153,34 +125,6 @@
                                                                     </div>
                                                                     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                                                                         <div data-radium="true">
-                                                                            <style>
-                                                                                .attributesKit p {
-                                                                                    margin-bottom: 4px;
-                                                                                    font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                                                                    font-size: 14px;
-                                                                                    color: #8A93A3;
-                                                                                    line-height: 21px;
-                                                                                    font-weight: regular;
-                                                                                }
-
-                                                                                .attributesKit p:last-child {
-                                                                                    margin-bottom: 0px;
-                                                                                }
-
-                                                                                .attributesKit ul {
-                                                                                    margin-left: 20px;
-                                                                                }
-
-                                                                                .attributesKit a {
-                                                                                    color: #747E8E;
-                                                                                    text-decoration: none;
-                                                                                    border-bottom: 1px solid #DCE0E8;
-                                                                                }
-
-                                                                                .attributesKit a:hover {
-                                                                                    border-bottom: none;
-                                                                                }
-                                                                            </style>
                                                                             <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                                                                                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.</p>
                                                                             </div>

--- a/fixtures/0092-object-of-array-with-block-description.md
+++ b/fixtures/0092-object-of-array-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0093a-object-of-array-with-sample.md
+++ b/fixtures/0093a-object-of-array-with-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0093b-object-of-array-with-inline-sample.md
+++ b/fixtures/0093b-object-of-array-with-inline-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0094-object-of-array-with-samples.md
+++ b/fixtures/0094-object-of-array-with-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0095-object-of-array-with-default.md
+++ b/fixtures/0095-object-of-array-with-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0096-object-of-array-with-object-sample.md
+++ b/fixtures/0096-object-of-array-with-object-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0097-object-of-array-with-object-samples.md
+++ b/fixtures/0097-object-of-array-with-object-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0098-object-of-array-with-object-default.md
+++ b/fixtures/0098-object-of-array-with-object-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0099aa-object-of-object-without-values.md
+++ b/fixtures/0099aa-object-of-object-without-values.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0099ab-object-of-object-without-values-with-description.md
+++ b/fixtures/0099ab-object-of-object-without-values-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -31,36 +59,7 @@
                                             <div style="position:absolute;top:-14px;left:-1px;width:1px;height:14px;background-color:#E8EBEE;" data-radium="true"></div>
                                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                                                 <div data-radium="true">
-                                                    <style>
-                                                        .attributesKit p {
-                                                            margin-bottom: 4px;
-                                                            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                                            font-size: 14px;
-                                                            color: #8A93A3;
-                                                            line-height: 21px;
-                                                            font-weight: regular;
-                                                        }
-
-                                                        .attributesKit p:last-child {
-                                                            margin-bottom: 0px;
-                                                        }
-
-                                                        .attributesKit ul {
-                                                            margin-left: 20px;
-                                                        }
-
-                                                        .attributesKit a {
-                                                            color: #747E8E;
-                                                            text-decoration: none;
-                                                            border-bottom: 1px solid #DCE0E8;
-                                                        }
-
-                                                        .attributesKit a:hover {
-                                                            border-bottom: none;
-                                                        }
-                                                    </style>
-                                                    <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-bottom:14px;padding-left:13px;"
-                                                        data-radium="true">
+                                                    <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-bottom:14px;padding-left:13px;" data-radium="true">
                                                         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
                                                     </div>
                                                 </div>

--- a/fixtures/0099ac-object-of-object-without-values-with-block-description.md
+++ b/fixtures/0099ac-object-of-object-without-values-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -31,36 +59,7 @@
                                             <div style="position:absolute;top:-14px;left:-1px;width:1px;height:14px;background-color:#E8EBEE;" data-radium="true"></div>
                                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                                                 <div data-radium="true">
-                                                    <style>
-                                                        .attributesKit p {
-                                                            margin-bottom: 4px;
-                                                            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                                            font-size: 14px;
-                                                            color: #8A93A3;
-                                                            line-height: 21px;
-                                                            font-weight: regular;
-                                                        }
-
-                                                        .attributesKit p:last-child {
-                                                            margin-bottom: 0px;
-                                                        }
-
-                                                        .attributesKit ul {
-                                                            margin-left: 20px;
-                                                        }
-
-                                                        .attributesKit a {
-                                                            color: #747E8E;
-                                                            text-decoration: none;
-                                                            border-bottom: 1px solid #DCE0E8;
-                                                        }
-
-                                                        .attributesKit a:hover {
-                                                            border-bottom: none;
-                                                        }
-                                                    </style>
-                                                    <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-bottom:14px;padding-left:13px;"
-                                                        data-radium="true">
+                                                    <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-bottom:14px;padding-left:13px;" data-radium="true">
                                                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tincidunt auctor erat nec vulputate. Donec ut urna urna. Phasellus nisl dolor, posuere non placerat a, efficitur nec elit. Cras mattis
                                                             nulla et volutpat ullamcorper.</p>
                                                         <p>Donec posuere ipsum at est egestas tempus. Nullam sed interdum eros. Proin accumsan sodales sodales. Nam consequat convallis augue vitae pretium. Maecenas quis orci fringilla ex interdum vestibulum

--- a/fixtures/0099ad-object-of-object-without-values-with-sample.md
+++ b/fixtures/0099ad-object-of-object-without-values-with-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0099ae-object-of-object-without-values-with-samples.md
+++ b/fixtures/0099ae-object-of-object-without-values-with-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0099af-object-of-object-without-values-with-default.md
+++ b/fixtures/0099af-object-of-object-without-values-with-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0099b-object-of-object.md
+++ b/fixtures/0099b-object-of-object.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0100-object-of-object-with-description.md
+++ b/fixtures/0100-object-of-object-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -59,34 +87,6 @@
                                                                                 </div>
                                                                                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                                                                                     <div data-radium="true">
-                                                                                        <style>
-                                                                                            .attributesKit p {
-                                                                                                margin-bottom: 4px;
-                                                                                                font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                                                                                font-size: 14px;
-                                                                                                color: #8A93A3;
-                                                                                                line-height: 21px;
-                                                                                                font-weight: regular;
-                                                                                            }
-
-                                                                                            .attributesKit p:last-child {
-                                                                                                margin-bottom: 0px;
-                                                                                            }
-
-                                                                                            .attributesKit ul {
-                                                                                                margin-left: 20px;
-                                                                                            }
-
-                                                                                            .attributesKit a {
-                                                                                                color: #747E8E;
-                                                                                                text-decoration: none;
-                                                                                                border-bottom: 1px solid #DCE0E8;
-                                                                                            }
-
-                                                                                            .attributesKit a:hover {
-                                                                                                border-bottom: none;
-                                                                                            }
-                                                                                        </style>
                                                                                         <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-top:6px;"
                                                                                             data-radium="true">
                                                                                             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
@@ -115,34 +115,6 @@
                                                                                 </div>
                                                                                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                                                                                     <div data-radium="true">
-                                                                                        <style>
-                                                                                            .attributesKit p {
-                                                                                                margin-bottom: 4px;
-                                                                                                font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                                                                                font-size: 14px;
-                                                                                                color: #8A93A3;
-                                                                                                line-height: 21px;
-                                                                                                font-weight: regular;
-                                                                                            }
-
-                                                                                            .attributesKit p:last-child {
-                                                                                                margin-bottom: 0px;
-                                                                                            }
-
-                                                                                            .attributesKit ul {
-                                                                                                margin-left: 20px;
-                                                                                            }
-
-                                                                                            .attributesKit a {
-                                                                                                color: #747E8E;
-                                                                                                text-decoration: none;
-                                                                                                border-bottom: 1px solid #DCE0E8;
-                                                                                            }
-
-                                                                                            .attributesKit a:hover {
-                                                                                                border-bottom: none;
-                                                                                            }
-                                                                                        </style>
                                                                                         <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-top:6px;"
                                                                                             data-radium="true">
                                                                                             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>

--- a/fixtures/0101-object-of-object-with-block-description.md
+++ b/fixtures/0101-object-of-object-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -59,34 +87,6 @@
                                                                                 </div>
                                                                                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                                                                                     <div data-radium="true">
-                                                                                        <style>
-                                                                                            .attributesKit p {
-                                                                                                margin-bottom: 4px;
-                                                                                                font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                                                                                font-size: 14px;
-                                                                                                color: #8A93A3;
-                                                                                                line-height: 21px;
-                                                                                                font-weight: regular;
-                                                                                            }
-
-                                                                                            .attributesKit p:last-child {
-                                                                                                margin-bottom: 0px;
-                                                                                            }
-
-                                                                                            .attributesKit ul {
-                                                                                                margin-left: 20px;
-                                                                                            }
-
-                                                                                            .attributesKit a {
-                                                                                                color: #747E8E;
-                                                                                                text-decoration: none;
-                                                                                                border-bottom: 1px solid #DCE0E8;
-                                                                                            }
-
-                                                                                            .attributesKit a:hover {
-                                                                                                border-bottom: none;
-                                                                                            }
-                                                                                        </style>
                                                                                         <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-top:6px;"
                                                                                             data-radium="true">
                                                                                             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tincidunt auctor erat nec vulputate. Donec ut urna urna. Phasellus nisl dolor, posuere non placerat
@@ -142,34 +142,6 @@
                                                                                 </div>
                                                                                 <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                                                                                     <div data-radium="true">
-                                                                                        <style>
-                                                                                            .attributesKit p {
-                                                                                                margin-bottom: 4px;
-                                                                                                font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                                                                                font-size: 14px;
-                                                                                                color: #8A93A3;
-                                                                                                line-height: 21px;
-                                                                                                font-weight: regular;
-                                                                                            }
-
-                                                                                            .attributesKit p:last-child {
-                                                                                                margin-bottom: 0px;
-                                                                                            }
-
-                                                                                            .attributesKit ul {
-                                                                                                margin-left: 20px;
-                                                                                            }
-
-                                                                                            .attributesKit a {
-                                                                                                color: #747E8E;
-                                                                                                text-decoration: none;
-                                                                                                border-bottom: 1px solid #DCE0E8;
-                                                                                            }
-
-                                                                                            .attributesKit a:hover {
-                                                                                                border-bottom: none;
-                                                                                            }
-                                                                                        </style>
                                                                                         <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-top:6px;"
                                                                                             data-radium="true">
                                                                                             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tincidunt auctor erat nec vulputate. Donec ut urna urna. Phasellus nisl dolor, posuere non placerat

--- a/fixtures/0102-object-of-object-with-sample.md
+++ b/fixtures/0102-object-of-object-with-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0103-object-of-object-with-samples.md
+++ b/fixtures/0103-object-of-object-with-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0104-object-of-object-with-default.md
+++ b/fixtures/0104-object-of-object-with-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0105-object-of-object-with-object-sample.md
+++ b/fixtures/0105-object-of-object-with-object-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0106-object-of-object-with-object-samples.md
+++ b/fixtures/0106-object-of-object-with-object-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0107-object-of-object-with-object-default.md
+++ b/fixtures/0107-object-of-object-with-object-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0108-object-of-object-with-enum.md
+++ b/fixtures/0108-object-of-object-with-enum.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0109-object-of-object-with-enum-with-description.md
+++ b/fixtures/0109-object-of-object-with-enum-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -31,36 +59,7 @@
                                             <div style="position:absolute;top:-14px;left:-1px;width:1px;height:14px;background-color:transparent;" data-radium="true"></div>
                                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                                                 <div data-radium="true">
-                                                    <style>
-                                                        .attributesKit p {
-                                                            margin-bottom: 4px;
-                                                            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                                            font-size: 14px;
-                                                            color: #8A93A3;
-                                                            line-height: 21px;
-                                                            font-weight: regular;
-                                                        }
-
-                                                        .attributesKit p:last-child {
-                                                            margin-bottom: 0px;
-                                                        }
-
-                                                        .attributesKit ul {
-                                                            margin-left: 20px;
-                                                        }
-
-                                                        .attributesKit a {
-                                                            color: #747E8E;
-                                                            text-decoration: none;
-                                                            border-bottom: 1px solid #DCE0E8;
-                                                        }
-
-                                                        .attributesKit a:hover {
-                                                            border-bottom: none;
-                                                        }
-                                                    </style>
-                                                    <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-bottom:14px;padding-left:13px;"
-                                                        data-radium="true">
+                                                    <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-bottom:14px;padding-left:13px;" data-radium="true">
                                                         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
                                                     </div>
                                                 </div>

--- a/fixtures/0110-object-of-object-with-enum-with-block-description.md
+++ b/fixtures/0110-object-of-object-with-enum-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -31,36 +59,7 @@
                                             <div style="position:absolute;top:-14px;left:-1px;width:1px;height:14px;background-color:transparent;" data-radium="true"></div>
                                             <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                                                 <div data-radium="true">
-                                                    <style>
-                                                        .attributesKit p {
-                                                            margin-bottom: 4px;
-                                                            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                                            font-size: 14px;
-                                                            color: #8A93A3;
-                                                            line-height: 21px;
-                                                            font-weight: regular;
-                                                        }
-
-                                                        .attributesKit p:last-child {
-                                                            margin-bottom: 0px;
-                                                        }
-
-                                                        .attributesKit ul {
-                                                            margin-left: 20px;
-                                                        }
-
-                                                        .attributesKit a {
-                                                            color: #747E8E;
-                                                            text-decoration: none;
-                                                            border-bottom: 1px solid #DCE0E8;
-                                                        }
-
-                                                        .attributesKit a:hover {
-                                                            border-bottom: none;
-                                                        }
-                                                    </style>
-                                                    <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-bottom:14px;padding-left:13px;"
-                                                        data-radium="true">
+                                                    <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;margin-bottom:14px;padding-left:13px;" data-radium="true">
                                                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tincidunt auctor erat nec vulputate. Donec ut urna urna. Phasellus nisl dolor, posuere non placerat a, efficitur nec elit. Cras mattis
                                                             nulla et volutpat ullamcorper.</p>
                                                         <p>Donec posuere ipsum at est egestas tempus. Nullam sed interdum eros. Proin accumsan sodales sodales. Nam consequat convallis augue vitae pretium. Maecenas quis orci fringilla ex interdum vestibulum

--- a/fixtures/0111-object-of-object-with-enum-with-sample.md
+++ b/fixtures/0111-object-of-object-with-enum-with-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0112-object-of-object-with-enum-with-samples.md
+++ b/fixtures/0112-object-of-object-with-enum-with-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0113-object-of-object-with-enum-with-default.md
+++ b/fixtures/0113-object-of-object-with-enum-with-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0114-object-of-object-with-enum-with-object-sample.md
+++ b/fixtures/0114-object-of-object-with-enum-with-object-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0115-object-of-object-with-enum-with-object-samples.md
+++ b/fixtures/0115-object-of-object-with-enum-with-object-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0116-object-of-object-with-enum-with-object-default.md
+++ b/fixtures/0116-object-of-object-with-enum-with-object-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0117-object-of-mixed-structure-types.md
+++ b/fixtures/0117-object-of-mixed-structure-types.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Object</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;border-top:1px solid #D2D8DE;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0118-enum-of-strings.md
+++ b/fixtures/0118-enum-of-strings.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0118a-enum-of-strings-with-enum-description.md
+++ b/fixtures/0118a-enum-of-strings-with-enum-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0118aa-enum-of-strings-with-enum-block-description.md
+++ b/fixtures/0118aa-enum-of-strings-with-enum-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0118aaa-enum-of-strings-with-description.md
+++ b/fixtures/0118aaa-enum-of-strings-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -25,34 +53,6 @@
                         </div>
                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                             <div data-radium="true">
-                                <style>
-                                    .attributesKit p {
-                                        margin-bottom: 4px;
-                                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                        font-size: 14px;
-                                        color: #8A93A3;
-                                        line-height: 21px;
-                                        font-weight: regular;
-                                    }
-
-                                    .attributesKit p:last-child {
-                                        margin-bottom: 0px;
-                                    }
-
-                                    .attributesKit ul {
-                                        margin-left: 20px;
-                                    }
-
-                                    .attributesKit a {
-                                        color: #747E8E;
-                                        text-decoration: none;
-                                        border-bottom: 1px solid #DCE0E8;
-                                    }
-
-                                    .attributesKit a:hover {
-                                        border-bottom: none;
-                                    }
-                                </style>
                                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                                     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
                                 </div>
@@ -78,34 +78,6 @@
                         </div>
                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                             <div data-radium="true">
-                                <style>
-                                    .attributesKit p {
-                                        margin-bottom: 4px;
-                                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                        font-size: 14px;
-                                        color: #8A93A3;
-                                        line-height: 21px;
-                                        font-weight: regular;
-                                    }
-
-                                    .attributesKit p:last-child {
-                                        margin-bottom: 0px;
-                                    }
-
-                                    .attributesKit ul {
-                                        margin-left: 20px;
-                                    }
-
-                                    .attributesKit a {
-                                        color: #747E8E;
-                                        text-decoration: none;
-                                        border-bottom: 1px solid #DCE0E8;
-                                    }
-
-                                    .attributesKit a:hover {
-                                        border-bottom: none;
-                                    }
-                                </style>
                                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                                     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
                                 </div>

--- a/fixtures/0118ba-enum-of-strings-with-block-description.md
+++ b/fixtures/0118ba-enum-of-strings-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0118bb-enum-of-strings-with-sample.md
+++ b/fixtures/0118bb-enum-of-strings-with-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0118bc-enum-of-strings-with-samples.md
+++ b/fixtures/0118bc-enum-of-strings-with-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0118bd-enum-of-strings-with-default.md
+++ b/fixtures/0118bd-enum-of-strings-with-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0118c-enum-of-strings-with-enum-sample.md
+++ b/fixtures/0118c-enum-of-strings-with-enum-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0118d-enum-of-strings-with-enum-samples.md
+++ b/fixtures/0118d-enum-of-strings-with-enum-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0118e-enum-of-strings-with-enum-default.md
+++ b/fixtures/0118e-enum-of-strings-with-enum-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0119-enum-of-numbers.md
+++ b/fixtures/0119-enum-of-numbers.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0119a-enum-of-numbers-with-description.md
+++ b/fixtures/0119a-enum-of-numbers-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -25,34 +53,6 @@
                         </div>
                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                             <div data-radium="true">
-                                <style>
-                                    .attributesKit p {
-                                        margin-bottom: 4px;
-                                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                        font-size: 14px;
-                                        color: #8A93A3;
-                                        line-height: 21px;
-                                        font-weight: regular;
-                                    }
-
-                                    .attributesKit p:last-child {
-                                        margin-bottom: 0px;
-                                    }
-
-                                    .attributesKit ul {
-                                        margin-left: 20px;
-                                    }
-
-                                    .attributesKit a {
-                                        color: #747E8E;
-                                        text-decoration: none;
-                                        border-bottom: 1px solid #DCE0E8;
-                                    }
-
-                                    .attributesKit a:hover {
-                                        border-bottom: none;
-                                    }
-                                </style>
                                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                                     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
                                 </div>
@@ -78,34 +78,6 @@
                         </div>
                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                             <div data-radium="true">
-                                <style>
-                                    .attributesKit p {
-                                        margin-bottom: 4px;
-                                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                        font-size: 14px;
-                                        color: #8A93A3;
-                                        line-height: 21px;
-                                        font-weight: regular;
-                                    }
-
-                                    .attributesKit p:last-child {
-                                        margin-bottom: 0px;
-                                    }
-
-                                    .attributesKit ul {
-                                        margin-left: 20px;
-                                    }
-
-                                    .attributesKit a {
-                                        color: #747E8E;
-                                        text-decoration: none;
-                                        border-bottom: 1px solid #DCE0E8;
-                                    }
-
-                                    .attributesKit a:hover {
-                                        border-bottom: none;
-                                    }
-                                </style>
                                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                                     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
                                 </div>
@@ -131,34 +103,6 @@
                         </div>
                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                             <div data-radium="true">
-                                <style>
-                                    .attributesKit p {
-                                        margin-bottom: 4px;
-                                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                        font-size: 14px;
-                                        color: #8A93A3;
-                                        line-height: 21px;
-                                        font-weight: regular;
-                                    }
-
-                                    .attributesKit p:last-child {
-                                        margin-bottom: 0px;
-                                    }
-
-                                    .attributesKit ul {
-                                        margin-left: 20px;
-                                    }
-
-                                    .attributesKit a {
-                                        color: #747E8E;
-                                        text-decoration: none;
-                                        border-bottom: 1px solid #DCE0E8;
-                                    }
-
-                                    .attributesKit a:hover {
-                                        border-bottom: none;
-                                    }
-                                </style>
                                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                                     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
                                 </div>

--- a/fixtures/0119aa-enum-of-numbers-with-block-description.md
+++ b/fixtures/0119aa-enum-of-numbers-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0119aaa-enum-of-numbers-with-enum-description.md
+++ b/fixtures/0119aaa-enum-of-numbers-with-enum-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0119b-enum-of-numbers-with-enum-block-description.md
+++ b/fixtures/0119b-enum-of-numbers-with-enum-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0119c-enum-of-numbers-with-sample.md
+++ b/fixtures/0119c-enum-of-numbers-with-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0119d-enum-of-numbers-with-samples.md
+++ b/fixtures/0119d-enum-of-numbers-with-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0119e-enum-of-numbers-with-default.md
+++ b/fixtures/0119e-enum-of-numbers-with-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0119f-enum-of-numbers-with-enum-sample.md
+++ b/fixtures/0119f-enum-of-numbers-with-enum-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0119g-enum-of-numbers-with-enum-samples.md
+++ b/fixtures/0119g-enum-of-numbers-with-enum-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0119h-enum-of-numbers-with-enum-default.md
+++ b/fixtures/0119h-enum-of-numbers-with-enum-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0120-enum-of-booleans.md
+++ b/fixtures/0120-enum-of-booleans.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0120a-enum-of-booleans-with-description.md
+++ b/fixtures/0120a-enum-of-booleans-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">
@@ -25,34 +53,6 @@
                         </div>
                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                             <div data-radium="true">
-                                <style>
-                                    .attributesKit p {
-                                        margin-bottom: 4px;
-                                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                        font-size: 14px;
-                                        color: #8A93A3;
-                                        line-height: 21px;
-                                        font-weight: regular;
-                                    }
-
-                                    .attributesKit p:last-child {
-                                        margin-bottom: 0px;
-                                    }
-
-                                    .attributesKit ul {
-                                        margin-left: 20px;
-                                    }
-
-                                    .attributesKit a {
-                                        color: #747E8E;
-                                        text-decoration: none;
-                                        border-bottom: 1px solid #DCE0E8;
-                                    }
-
-                                    .attributesKit a:hover {
-                                        border-bottom: none;
-                                    }
-                                </style>
                                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                                     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
                                 </div>
@@ -78,34 +78,6 @@
                         </div>
                         <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
                             <div data-radium="true">
-                                <style>
-                                    .attributesKit p {
-                                        margin-bottom: 4px;
-                                        font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
-                                        font-size: 14px;
-                                        color: #8A93A3;
-                                        line-height: 21px;
-                                        font-weight: regular;
-                                    }
-
-                                    .attributesKit p:last-child {
-                                        margin-bottom: 0px;
-                                    }
-
-                                    .attributesKit ul {
-                                        margin-left: 20px;
-                                    }
-
-                                    .attributesKit a {
-                                        color: #747E8E;
-                                        text-decoration: none;
-                                        border-bottom: 1px solid #DCE0E8;
-                                    }
-
-                                    .attributesKit a:hover {
-                                        border-bottom: none;
-                                    }
-                                </style>
                                 <div style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:13px;color:#8A93A3;line-height:150%;font-weight:regular;" data-radium="true">
                                     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
                                 </div>

--- a/fixtures/0120aa-enum-of-booleans-with-block-description.md
+++ b/fixtures/0120aa-enum-of-booleans-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0120aaa-enum-of-booleans-with-enum-description.md
+++ b/fixtures/0120aaa-enum-of-booleans-with-enum-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0120b-enum-of-booleans-with-enum-block-description.md
+++ b/fixtures/0120b-enum-of-booleans-with-enum-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0120c-enum-of-booleans-with-sample.md
+++ b/fixtures/0120c-enum-of-booleans-with-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0120d-enum-of-booleans-with-samples.md
+++ b/fixtures/0120d-enum-of-booleans-with-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0120e-enum-of-booleans-with-default.md
+++ b/fixtures/0120e-enum-of-booleans-with-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0120f-enum-of-booleans-with-enum-sample.md
+++ b/fixtures/0120f-enum-of-booleans-with-enum-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0120g-enum-of-booleans-with-enum-samples.md
+++ b/fixtures/0120g-enum-of-booleans-with-enum-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0120h-enum-of-booleans-with-enum-default.md
+++ b/fixtures/0120h-enum-of-booleans-with-enum-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0121-enum-of-mixed-primitive-types.md
+++ b/fixtures/0121-enum-of-mixed-primitive-types.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0122-enum-of-objects.md
+++ b/fixtures/0122-enum-of-objects.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0122a-enum-of-objects-with-description.md
+++ b/fixtures/0122a-enum-of-objects-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0122b-enum-of-objects-with-block-description.md
+++ b/fixtures/0122b-enum-of-objects-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0122c-enum-of-objects-with-enum-description.md
+++ b/fixtures/0122c-enum-of-objects-with-enum-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0122d-enum-of-objects-with-enum-block-description.md
+++ b/fixtures/0122d-enum-of-objects-with-enum-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0122e-enum-of-objects-with-sample.md
+++ b/fixtures/0122e-enum-of-objects-with-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0122f-enum-of-objects-with-samples.md
+++ b/fixtures/0122f-enum-of-objects-with-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0122g-enum-of-objects-with-default.md
+++ b/fixtures/0122g-enum-of-objects-with-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0122h-enum-of-objects-with-enum-sample.md
+++ b/fixtures/0122h-enum-of-objects-with-enum-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0122i-enum-of-objects-with-enum-samples.md
+++ b/fixtures/0122i-enum-of-objects-with-enum-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0122j-enum-of-objects-with-enum-default.md
+++ b/fixtures/0122j-enum-of-objects-with-enum-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0123-enum-of-arrays.md
+++ b/fixtures/0123-enum-of-arrays.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0123a-enum-of-arrays-with-description.md
+++ b/fixtures/0123a-enum-of-arrays-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0123b-enum-of-arrays-with-block-description.md
+++ b/fixtures/0123b-enum-of-arrays-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0123c-enum-of-arrays-with-enum-description.md
+++ b/fixtures/0123c-enum-of-arrays-with-enum-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0123d-enum-of-arrays-with-enum-block-description.md
+++ b/fixtures/0123d-enum-of-arrays-with-enum-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0123e-enum-of-arrays-with-sample.md
+++ b/fixtures/0123e-enum-of-arrays-with-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0123f-enum-of-arrays-with-samples.md
+++ b/fixtures/0123f-enum-of-arrays-with-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0123g-enum-of-arrays-with-default.md
+++ b/fixtures/0123g-enum-of-arrays-with-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0123h-enum-of-arrays-with-enum-sample.md
+++ b/fixtures/0123h-enum-of-arrays-with-enum-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0123i-enum-of-arrays-with-enum-samples.md
+++ b/fixtures/0123i-enum-of-arrays-with-enum-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0123j-enum-of-arrays-with-enum-default.md
+++ b/fixtures/0123j-enum-of-arrays-with-enum-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0124-enum-of-enums.md
+++ b/fixtures/0124-enum-of-enums.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0124a-enum-of-enums-with-description.md
+++ b/fixtures/0124a-enum-of-enums-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0124b-enum-of-enums-with-block-description.md
+++ b/fixtures/0124b-enum-of-enums-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0124c-enum-of-enums-with-enum-description.md
+++ b/fixtures/0124c-enum-of-enums-with-enum-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0124d-enum-of-enums-with-enum-block-description.md
+++ b/fixtures/0124d-enum-of-enums-with-enum-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0124e-enum-of-enums-with-sample.md
+++ b/fixtures/0124e-enum-of-enums-with-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0124f-enum-of-enums-with-samples.md
+++ b/fixtures/0124f-enum-of-enums-with-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0124g-enum-of-enums-with-default.md
+++ b/fixtures/0124g-enum-of-enums-with-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0124h-enum-of-enums-with-enum-sample.md
+++ b/fixtures/0124h-enum-of-enums-with-enum-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0124i-enum-of-enums-with-enum-samples.md
+++ b/fixtures/0124i-enum-of-enums-with-enum-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0124j-enum-of-enums-with-enum-default.md
+++ b/fixtures/0124j-enum-of-enums-with-enum-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0125-enum-of-mixed-types.md
+++ b/fixtures/0125-enum-of-mixed-types.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0125a-enum-of-mixed-types-with-description.md
+++ b/fixtures/0125a-enum-of-mixed-types-with-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0125b-enum-of-mixed-types-with-block-description.md
+++ b/fixtures/0125b-enum-of-mixed-types-with-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0125c-enum-of-mixed-types-with-enum-description.md
+++ b/fixtures/0125c-enum-of-mixed-types-with-enum-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0125d-enum-of-mixed-types-with-enum-block-description.md
+++ b/fixtures/0125d-enum-of-mixed-types-with-enum-block-description.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0125e-enum-of-mixed-types-with-sample.md
+++ b/fixtures/0125e-enum-of-mixed-types-with-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0125f-enum-of-mixed-types-with-samples.md
+++ b/fixtures/0125f-enum-of-mixed-types-with-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0125g-enum-of-mixed-types-with-default.md
+++ b/fixtures/0125g-enum-of-mixed-types-with-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0125h-enum-of-mixed-types-with-enum-sample.md
+++ b/fixtures/0125h-enum-of-mixed-types-with-enum-sample.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0125i-enum-of-mixed-types-with-enum-samples.md
+++ b/fixtures/0125i-enum-of-mixed-types-with-enum-samples.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/fixtures/0125j-enum-of-mixed-types-with-enum-default.md
+++ b/fixtures/0125j-enum-of-mixed-types-with-enum-default.md
@@ -2,6 +2,34 @@
     <div style="padding-bottom:10px;" data-radium="true">
         <h1 style="font-family:&#x27;Source Sans Pro&#x27;, -apple-system, Helvetica, sans-serif;font-size:18px;color:#5D6470;" data-radium="true">My Enum</h1>
     </div>
+    <style>
+        .attributesKit p {
+            margin-bottom: 4px;
+            font-family: 'Source Sans Pro', -apple-system, Helvetica, sans-serif;
+            font-size: 14px;
+            color: #8A93A3;
+            line-height: 21px;
+            font-weight: regular;
+        }
+
+        .attributesKit p:last-child {
+            margin-bottom: 0px;
+        }
+
+        .attributesKit ul {
+            margin-left: 20px;
+        }
+
+        .attributesKit a {
+            color: #747E8E;
+            text-decoration: none;
+            border-bottom: 1px solid #DCE0E8;
+        }
+
+        .attributesKit a:hover {
+            border-bottom: none;
+        }
+    </style>
     <div style="width:100%;height:auto;display:flex;flex-direction:row;flex-wrap:no-wrap;justify-content:flex-start;align-items:stretch;position:relative;">
         <div style="-ms-flex-wrap:no-wrap;-webkit-box-align:start;-ms-flex-align:start;-webkit-box-pack:start;-ms-flex-pack:start;-webkit-box-lines:no-wrap;-webkit-box-direction:normal;-webkit-flex-direction:column;-ms-flex-direction:column;-webkit-flex-wrap:no-wrap;-webkit-box-orient:vertical;-webkit-justify-content:flex-start;-webkit-align-items:flex-start;width:100%;align-items:flex-start;justify-content:flex-start;flex-wrap:no-wrap;flex-direction:column;display:-webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;height:auto;"
             data-radium="true">

--- a/src/Components/Attributes/Attributes.js
+++ b/src/Components/Attributes/Attributes.js
@@ -9,9 +9,11 @@ import map from 'lodash/map';
 import merge from 'lodash/merge';
 import React from 'react';
 import reduce from 'lodash/reduce';
+import { Style } from 'radium';
 
 import Attribute from '../Attribute/Attribute';
 import Title from '../Title/Title';
+import { DEFAULT_FONT_FAMILY } from '../../Constants/fonts';
 
 import { preprocess } from '../../Modules/Preprocessor/Preprocessor';
 import { preprocessSamples } from '../../Modules/SamplesPreprocessor/SamplesPreprocessor';
@@ -120,10 +122,10 @@ class Attributes extends React.Component {
         } else {
           result[dataStructure.meta.id] = dataStructure;
         }
+
         return result;
       }, {})
     );
-
 
     const dereferencedDataStructures = props.dereferencedDataStructures || (
       map(dataStructures, (dataStructure) =>
@@ -255,6 +257,7 @@ class Attributes extends React.Component {
 
       return null;
     }
+    const DESCRIPTION_COLOR = this.state.theme.DESCRIPTION_COLOR;
 
     return (
       <div className="attributesKit">
@@ -262,6 +265,34 @@ class Attributes extends React.Component {
           this.state.title &&
             <Title element={this.state.element} />
         }
+
+        <Style
+          scopeSelector=".attributesKit"
+          rules={{
+            p: {
+              marginBottom: '4px',
+              fontFamily: DEFAULT_FONT_FAMILY,
+              fontSize: '14px',
+              color: DESCRIPTION_COLOR,
+              lineHeight: '21px',
+              fontWeight: 'regular',
+            },
+            'p:last-child': {
+              marginBottom: '0px',
+            },
+            ul: {
+              marginLeft: '20px',
+            },
+            a: {
+              color: '#747E8E',
+              textDecoration: 'none',
+              borderBottom: '1px solid #DCE0E8',
+            },
+            'a:hover': {
+              borderBottom: 'none',
+            },
+          }}
+        />
 
         <Attribute
           element={this.state.element}

--- a/src/Components/Description/Description.js
+++ b/src/Components/Description/Description.js
@@ -2,7 +2,7 @@ import isObject from 'lodash/isObject';
 import isString from 'lodash/isString';
 import marked from 'marked';
 import merge from 'lodash/merge';
-import Radium, { Style } from 'radium';
+import Radium from 'radium';
 import React from 'react';
 
 import { DEFAULT_FONT_FAMILY } from '../../Constants/fonts';
@@ -53,7 +53,6 @@ class Description extends React.Component {
   };
 
   render() {
-    const { DESCRIPTION_COLOR } = this.context.theme;
     const description = Description.getDescription(this.props.element);
 
     if (!description) {
@@ -64,33 +63,6 @@ class Description extends React.Component {
 
     return (
       <div>
-        <Style
-          scopeSelector=".attributesKit"
-          rules={{
-            p: {
-              marginBottom: '4px',
-              fontFamily: DEFAULT_FONT_FAMILY,
-              fontSize: '14px',
-              color: DESCRIPTION_COLOR,
-              lineHeight: '21px',
-              fontWeight: 'regular',
-            },
-            'p:last-child': {
-              marginBottom: '0px',
-            },
-            ul: {
-              marginLeft: '20px',
-            },
-            a: {
-              color: '#747E8E',
-              textDecoration: 'none',
-              borderBottom: '1px solid #DCE0E8',
-            },
-            'a:hover': {
-              borderBottom: 'none',
-            },
-          }}
-        />
         <div
           style={this.style.base}
           dangerouslySetInnerHTML={markdownMarkup}


### PR DESCRIPTION
- Every description made `<style>` block with global styles. 
- Browser had to match DOM on every description element
- Global styles for description moved to attributes kit root