### PR TITLE
Update propagating collapseByDefault into Value

### DIFF
--- a/src/Components/ObjectProperty/StructuredObjectProperty.js
+++ b/src/Components/ObjectProperty/StructuredObjectProperty.js
@@ -199,6 +199,7 @@ class StructuredObjectProperty extends React.Component {
                   <Value
                     element={this.props.element}
                     parentElement={this.props.parentElement}
+                    collapseByDefault={this.props.collapseByDefault}
                   />
                 </Row>
               </Ruler>

--- a/src/Components/Value/Value.js
+++ b/src/Components/Value/Value.js
@@ -21,6 +21,7 @@ class Value extends React.Component {
     style: React.PropTypes.object,
     expandableCollapsible: React.PropTypes.bool,
     isSample: React.PropTypes.bool,
+    collapseByDefault: React.PropTypes.bool,
   };
 
   render() {
@@ -39,6 +40,7 @@ class Value extends React.Component {
             parentElement={this.props.parentElement}
             style={this.props.style}
             isSample={this.props.isSample}
+            collapseByDefault={this.props.collapseByDefault}
           />
         );
       }
@@ -59,6 +61,7 @@ class Value extends React.Component {
           parentElement={this.props.parentElement}
           style={this.props.style}
           isSample={this.props.isSample}
+          collapseByDefault={this.props.collapseByDefault}
         />
       );
     } else if (
@@ -72,6 +75,7 @@ class Value extends React.Component {
           parentElement={this.props.parentElement}
           style={this.props.style}
           isSample={this.props.isSample}
+          collapseByDefault={this.props.collapseByDefault}
         />
       );
     } else if (!isUndefined(this.props.element.content)) {


### PR DESCRIPTION
- `Value` didn’t get info about `collapseByDefault` but there was nested collapsable structures in `Value`.