### PR TITLE
Support JSON Schema in the playground

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,5 +149,9 @@
   },
   "release": {
     "verifyConditions": "condition-circle"
+  },
+  "dependencies": {
+    "minim": "^0.16.0",
+    "minim-parse-result": "^0.5.0"
   }
 }

--- a/playground/schema.js
+++ b/playground/schema.js
@@ -1,0 +1,205 @@
+import _ from 'lodash';
+import minim from 'minim';
+import parseResult from 'minim-parse-result';
+
+const namespace = minim.namespace()
+  .use(parseResult);
+
+// import DataStructureGenerator from 'fury-adapter-swagger/schema';
+class DataStructureGenerator {
+  constructor(minim) {
+    this.minim = minim;
+  }
+
+  // Generates a data structure element representing the given schema
+  generateDataStructure(schema) {
+    const { DataStructure } = this.minim.elements;
+    const element = this.generateElement(schema);
+    const dataStructure = new DataStructure(element);
+    return dataStructure;
+  }
+
+  // Generates a member element for a property in a schema
+  generateMember(name, property) {
+    const {
+      String: StringElement,
+      Member: MemberElement,
+    } = this.minim.elements;
+
+    const member = new MemberElement();
+    member.key = new StringElement(name);
+    member.value = this.generateElement(property);
+
+    if (property.description) {
+      member.description = property.description;
+    }
+
+    return member;
+  }
+
+  // Generates an enum element for the given enum schema
+  generateEnum(schema) {
+    const { Array: ArrayElement } = this.minim.elements;
+    const element = new ArrayElement(schema.enum);
+    element.element = 'enum';
+    return element;
+  }
+
+  // Generates an object element from the given object schema
+  generateObject(schema) {
+    const {
+      Array: ArrayElement,
+      Object: ObjectElement,
+      String: StringElement,
+    } = this.minim.elements;
+
+    const element = new ObjectElement();
+
+    if (schema.properties) {
+      element.content = _.map(schema.properties, (subschema, property) => {
+        const member = this.generateMember(property, subschema);
+
+        const required = schema.required && schema.required.includes(property);
+        member.attributes.typeAttributes = new ArrayElement([
+          new StringElement(required ? 'required' : 'optional'),
+        ]);
+
+        return member;
+      });
+    }
+
+    return element;
+  }
+
+  // Generates an array element from the given array schema
+  generateArray(schema) {
+    const { Array: ArrayElement } = this.minim.elements;
+    const element = new ArrayElement();
+
+    if (schema.items) {
+      if (_.isArray(schema.items)) {
+        schema.items.forEach((item) => {
+          element.push(this.generateElement(item));
+        });
+      } else {
+        element.push(this.generateElement(schema.items));
+      }
+    }
+
+    return element;
+  }
+
+  // Generates an array of descriptions for each validation rule in the given schema.
+  generateValidationDescriptions(schema) {
+    const validations = {
+      // String
+      pattern: value => `Matches regex pattern: \`${value}\``,
+      maxLength: value => `Length of string must be less than, or equal to ${value}`,
+      minLength: value => `Length of string must be greater than, or equal to ${value}`,
+
+      // Number
+      multipleOf: value => `Number must be a multiple of ${value}`,
+      maximum: value => `Number must be less than, or equal to ${value}`,
+      minimum: value => `Number must be more than, or equal to ${value}`,
+      exclusiveMaximum: value => `Number must be less than ${value}`,
+      exclusiveMinimum: value => `Number must be more than ${value}`,
+
+      // Object
+      minProperties: value => `Object must have more than, or equal to ${value} properties`,
+      maxProperties: value => `Object must have less than, or equal to ${value} properties`,
+
+      // Array
+      maxItems: value => `Array length must be less than, or equal to ${value}`,
+      minItems: value => `Array length must be more than, or equal to ${value}`,
+      uniqueItems: () => 'Array contents must be unique',
+
+      // Other
+      format: value => `Value must be of format '${value}'`,
+    };
+
+    return _
+      .chain(validations)
+      .map((value, key) => {
+        if (schema[key]) {
+          return value(schema[key]);
+        }
+
+        return null;
+      })
+      .compact()
+      .value();
+  }
+
+  // Generates an element representing the given schema
+  generateElement(schema) {
+    const {
+      String: StringElement,
+      Number: NumberElement,
+      Boolean: BooleanElement,
+      Null: NullElement,
+    } = this.minim.elements;
+
+    const typeGeneratorMap = {
+      boolean: BooleanElement,
+      string: StringElement,
+      number: NumberElement,
+      null: NullElement,
+    };
+
+    let element;
+
+    if (schema.enum) {
+      element = this.generateEnum(schema);
+    } else if (schema.type === 'array') {
+      element = this.generateArray(schema);
+    } else if (schema.type === 'object') {
+      element = this.generateObject(schema);
+    } else if (schema.type && typeGeneratorMap[schema.type]) {
+      element = new typeGeneratorMap[schema.type]();
+    } else if (_.isArray(schema.type)) {
+      // TODO: Support multiple `type`
+    }
+
+    if (element) {
+      if (schema.title) {
+        element.title = new StringElement(schema.title);
+      }
+
+      if (schema.description) {
+        element.description = new StringElement(schema.description);
+      }
+
+      if (schema.default !== undefined && !_.isArray(schema.default) &&
+          !_.isObject(schema.default)) {
+        // TODO Support defaults for arrays and objects
+        element.attributes.set('default', schema.default);
+      }
+
+      if (schema.examples && (schema.type === 'string' || schema.type === 'boolean' || schema.type === 'number')) {
+        // TODO examples for array/object or multiple types
+        element.attributes.set('samples', schema.examples);
+      }
+
+      const validationDescriptions = this.generateValidationDescriptions(schema);
+
+      if (validationDescriptions.length > 0) {
+        const description = validationDescriptions.map(value => `- ${value}`);
+
+        if (element.description && element.description.toValue()) {
+          description.splice(0, 0, `${element.description.toValue()}\n`);
+        }
+
+        element.description = new StringElement(description.join('\n'));
+      }
+    }
+
+    return element;
+  }
+}
+
+export default function parseJSONSchema(schema) {
+  const generator = new DataStructureGenerator(namespace);
+  const dataStructure = generator.generateDataStructure(schema);
+  const result = dataStructure.toRefract();
+  return [result.content];
+}

--- a/playground/server.js
+++ b/playground/server.js
@@ -4,6 +4,7 @@ import msonZoo from 'mson-zoo';
 import path from 'path';
 
 import parseMson from './parseMson';
+import parseJSONSchema from './schema';
 
 // Starts server
 const app = express();
@@ -11,6 +12,13 @@ const app = express();
 app.use(bodyparser.json());
 
 app.post('/parse', (req, res) => {
+  // Attempt to JSON parse the req body to check if its a JSON schema
+  try {
+    const schema = JSON.parse(req.body.source);
+    const dataStructures = parseJSONSchema(schema);
+    return res.json({ dataStructures });
+  } catch(error) {}
+
   parseMson(req.body.source, (err, dataStructures) =>
     res.json({ errors: err, dataStructures })
   );


### PR DESCRIPTION
This pull request adds support for parsing JSON Schema and rendering them as attributes in the rendered attributes kit table. This will come to the Swagger parser in https://github.com/apiaryio/fury-adapter-swagger/pull/104.

The implementation is very simplistic, we will attempt to JSON parse the users document, if that succeeds we will parse it as a JSON Schema. Otherwise we will continue assuming the document is MSON.

![screen shot 2017-06-02 at 13 00 45](https://cloud.githubusercontent.com/assets/44164/26724872/80b6bc70-4793-11e7-96b7-40e56705ed34.png)
