### PR TITLE
chore: lock condition-circle version

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "classnames": "2.2.5",
     "cli-table": "0.3.1",
     "colors": "1.1.2",
-    "condition-circle": "^1.5.0",
+    "condition-circle": "1.5.0",
     "css-loader": "^0.28.0",
     "dedent": "^0.7.0",
     "eidolon": "^1.5.3",


### PR DESCRIPTION
This should solve the semantic-release issue found on CircleCI:

```
npm run semantic-release || true

> attributes-kit@0.0.0-development semantic-release /home/ubuntu/attributes-kit
> semantic-release pre && npm publish && semantic-release post

/home/ubuntu/attributes-kit/node_modules/condition-circle/src/condition-circle.js:13
async function conditionCircle (pluginConfig, args) {
      ^^^^^^^^
SyntaxError: Unexpected token function
    at createScript (vm.js:56:10)
    at Object.runInThisContext (vm.js:97:10)
```