### PR TITLE
fix: correct Type.propTypes.reference

### DIFF
--- a/src/Components/Type/Type.js
+++ b/src/Components/Type/Type.js
@@ -13,7 +13,7 @@ import { MONO_FONT_FAMILY } from '../../Constants/fonts';
 class Type extends React.Component {
   static propTypes = {
     type: React.PropTypes.string,
-    reference: React.PropTypes.bool,
+    reference: React.PropTypes.string,
     element: React.PropTypes.object,
     onClick: React.PropTypes.func,
     style: React.PropTypes.object,


### PR DESCRIPTION
Introduced by the `props.type` vs. `props.reference` changes
done in https://github.com/apiaryio/attributes-kit/commit/67478830f1df7fb6625000fc7cd1b3722557c4a8#diff-15a15f6147a19c4bb4b7313354b90043R74 following from https://github.com/apiaryio/attributes-kit/commit/766e13d3ca6bc3925f9ad427d523e27fd6848006#diff-a51108c744398a795cdb84efeb6f624cL223.

Causing the `props.reference` to be expected of a string type as it is used to render the referenced type name at https://github.com/apiaryio/attributes-kit/blob/67478830f1df7fb6625000fc7cd1b3722557c4a8/src/Type/Type.js#L74