### PR TITLE
chore: use PropTypes in favor of React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-class-properties": "^6.5.2",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
+    "babel-plugin-transform-react-remove-prop-types": "0.4.13",
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.22.0",
@@ -134,7 +135,14 @@
       "transform-decorators-legacy",
       "transform-class-properties",
       "add-module-exports"
-    ]
+    ],
+    "env": {
+      "production": {
+        "plugins": [
+          "transform-react-remove-prop-types"
+        ]
+      }
+    }
   },
   "eslintConfig": {
     "extends": "airbnb",

--- a/package.json
+++ b/package.json
@@ -152,5 +152,8 @@
   },
   "release": {
     "verifyConditions": "condition-circle"
+  },
+  "dependencies": {
+    "prop-types": "15.6.2"
   }
 }

--- a/playground/components/Editor.js
+++ b/playground/components/Editor.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import AceEditor from 'react-ace';
 import dedent from 'dedent';
 import isArray from 'lodash/isArray';
@@ -14,7 +15,7 @@ import EditorActions from '../actions/editor';
 class EditorComponent extends React.Component {
 
   static propTypes = {
-    errors: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
+    errors: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   };
 
 

--- a/playground/components/JsonFormatter.js
+++ b/playground/components/JsonFormatter.js
@@ -1,16 +1,17 @@
 import eidolon from 'eidolon';
 import React from 'react';
 import ReactDom from 'react-dom';
+import PropTypes from 'prop-types';
 import JSONFormatter from 'json-formatter-js';
 
 // import 'json-formatter-js/dist/style.css';
 
 class JsonFormatter extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    dataStructures: React.PropTypes.oneOfType([
-      React.PropTypes.object, // minim
-      React.PropTypes.array, // legacy refract array
+    element: PropTypes.object,
+    dataStructures: PropTypes.oneOfType([
+      PropTypes.object, // minim
+      PropTypes.array, // legacy refract array
     ]),
   };
 

--- a/src/Components/Array/Array.js
+++ b/src/Components/Array/Array.js
@@ -1,6 +1,7 @@
 import merge from 'lodash/merge';
 import Radium from 'radium';
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { ArrayDefaults } from '../ArrayDefaults/ArrayDefaults';
 import ArrayHeader from '../ArrayHeader/ArrayHeader';
@@ -21,14 +22,14 @@ import {
 @Radium
 class ArrayComponent extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    parentElement: React.PropTypes.object,
-    style: React.PropTypes.object,
-    collapseByDefault: React.PropTypes.bool,
+    element: PropTypes.object,
+    parentElement: PropTypes.object,
+    style: PropTypes.object,
+    collapseByDefault: PropTypes.bool,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
+    theme: PropTypes.object,
   };
 
   constructor(props) {

--- a/src/Components/ArrayDefaults/ArrayDefaults.js
+++ b/src/Components/ArrayDefaults/ArrayDefaults.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 import merge from 'lodash/merge';
 
@@ -10,13 +11,13 @@ import SampleToggle from '../SampleToggle/SampleToggle';
 @Radium
 class ArrayDefaults extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    style: React.PropTypes.object,
-    collapseByDefault: React.PropTypes.bool,
+    element: PropTypes.object,
+    style: PropTypes.object,
+    collapseByDefault: PropTypes.bool,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
+    theme: PropTypes.object,
   };
 
   constructor(props) {

--- a/src/Components/ArrayHeader/ArrayHeader.js
+++ b/src/Components/ArrayHeader/ArrayHeader.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 import merge from 'lodash/merge';
 
@@ -7,13 +8,13 @@ import Row from '../Row/Row';
 @Radium
 class ArrayHeader extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    parentElement: React.PropTypes.object,
-    style: React.PropTypes.object,
+    element: PropTypes.object,
+    parentElement: PropTypes.object,
+    style: PropTypes.object,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
+    theme: PropTypes.object,
   };
 
   get style() {

--- a/src/Components/ArrayItem/ArrayItem.js
+++ b/src/Components/ArrayItem/ArrayItem.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 import merge from 'lodash/merge';
 
@@ -25,17 +26,17 @@ import {
 @Radium
 class ArrayItem extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    index: React.PropTypes.number,
-    parentElement: React.PropTypes.object,
-    showArrayItemIndex: React.PropTypes.bool,
-    showBullet: React.PropTypes.bool,
-    style: React.PropTypes.object,
-    collapseByDefault: React.PropTypes.bool,
+    element: PropTypes.object,
+    index: PropTypes.number,
+    parentElement: PropTypes.object,
+    showArrayItemIndex: PropTypes.bool,
+    showBullet: PropTypes.bool,
+    style: PropTypes.object,
+    collapseByDefault: PropTypes.bool,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
+    theme: PropTypes.object,
   };
 
   get style() {

--- a/src/Components/ArrayItem/StructuredArrayItem.js
+++ b/src/Components/ArrayItem/StructuredArrayItem.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 import merge from 'lodash/merge';
 
@@ -20,17 +21,17 @@ import {
 @Radium
 class StructuredArrayItem extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    index: React.PropTypes.number,
-    parentElement: React.PropTypes.object,
-    showArrayItemIndex: React.PropTypes.bool,
-    showBullet: React.PropTypes.bool,
-    style: React.PropTypes.object,
-    collapseByDefault: React.PropTypes.bool,
+    element: PropTypes.object,
+    index: PropTypes.number,
+    parentElement: PropTypes.object,
+    showArrayItemIndex: PropTypes.bool,
+    showBullet: PropTypes.bool,
+    style: PropTypes.object,
+    collapseByDefault: PropTypes.bool,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
+    theme: PropTypes.object,
   };
 
   constructor(props) {

--- a/src/Components/ArrayItemDefaults/ArrayItemDefaults.js
+++ b/src/Components/ArrayItemDefaults/ArrayItemDefaults.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 import merge from 'lodash/merge';
 
@@ -13,9 +14,9 @@ import {
 @Radium
 class ArrayItemDefaults extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    style: React.PropTypes.object,
-    collapseByDefault: React.PropTypes.bool,
+    element: PropTypes.object,
+    style: PropTypes.object,
+    collapseByDefault: PropTypes.bool,
   };
 
   get style() {

--- a/src/Components/ArrayItemIndex/ArrayItemIndex.js
+++ b/src/Components/ArrayItemIndex/ArrayItemIndex.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 import merge from 'lodash/merge';
 
@@ -7,8 +8,8 @@ import { MONO_FONT_FAMILY } from '../../Constants/fonts';
 @Radium
 class ArrayItemIndex extends React.Component {
   static propTypes = {
-    index: React.PropTypes.number,
-    style: React.PropTypes.object,
+    index: PropTypes.number,
+    style: PropTypes.object,
   };
 
   get style() {

--- a/src/Components/ArrayItemSamples/ArrayItemSamples.js
+++ b/src/Components/ArrayItemSamples/ArrayItemSamples.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 import merge from 'lodash/merge';
 
@@ -13,9 +14,9 @@ import {
 @Radium
 class ArrayItemSamples extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    style: React.PropTypes.object,
-    collapseByDefault: React.PropTypes.bool,
+    element: PropTypes.object,
+    style: PropTypes.object,
+    collapseByDefault: PropTypes.bool,
   };
 
   get style() {

--- a/src/Components/ArrayItems/ArrayItems.js
+++ b/src/Components/ArrayItems/ArrayItems.js
@@ -1,14 +1,15 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 import merge from 'lodash/merge';
 
 @Radium
 class ArrayItems extends React.Component {
   static propTypes = {
-    style: React.PropTypes.object,
-    children: React.PropTypes.oneOfType([
-      React.PropTypes.object,
-      React.PropTypes.array,
+    style: PropTypes.object,
+    children: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.array,
     ]),
   };
 

--- a/src/Components/ArraySample/ArraySample.js
+++ b/src/Components/ArraySample/ArraySample.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 import merge from 'lodash/merge';
 
@@ -10,14 +11,14 @@ import SampleToggle from '../SampleToggle/SampleToggle';
 @Radium
 class ArraySample extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    sample: React.PropTypes.object,
-    style: React.PropTypes.object,
-    collapseByDefault: React.PropTypes.bool,
+    element: PropTypes.object,
+    sample: PropTypes.object,
+    style: PropTypes.object,
+    collapseByDefault: PropTypes.bool,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
+    theme: PropTypes.object,
   };
 
   constructor(props) {

--- a/src/Components/ArraySamples/ArraySamples.js
+++ b/src/Components/ArraySamples/ArraySamples.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 import merge from 'lodash/merge';
 
@@ -7,9 +8,9 @@ import { ArraySample } from '../ArraySample/ArraySample';
 @Radium
 class ArraySamples extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    style: React.PropTypes.object,
-    collapseByDefault: React.PropTypes.bool,
+    element: PropTypes.object,
+    style: PropTypes.object,
+    collapseByDefault: PropTypes.bool,
   };
 
   get style() {

--- a/src/Components/Attribute/Attribute.js
+++ b/src/Components/Attribute/Attribute.js
@@ -1,15 +1,16 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Error from '../Error/Error';
 import refractToComponentsMap from '../../Resources/refractToComponentMap';
 
 class Attribute extends React.Component {
   static propTypes = {
-    theme: React.PropTypes.object,
-    element: React.PropTypes.object,
-    expandableCollapsible: React.PropTypes.bool,
-    parentElement: React.PropTypes.object,
-    collapseByDefault: React.PropTypes.bool,
-    isSample: React.PropTypes.bool,
+    theme: PropTypes.object,
+    element: PropTypes.object,
+    expandableCollapsible: PropTypes.bool,
+    parentElement: PropTypes.object,
+    collapseByDefault: PropTypes.bool,
+    isSample: PropTypes.bool,
   };
 
   render() {

--- a/src/Components/Attributes/Attributes.js
+++ b/src/Components/Attributes/Attributes.js
@@ -10,6 +10,7 @@ import isObject from 'lodash/isObject';
 import map from 'lodash/map';
 import merge from 'lodash/merge';
 import React from 'react';
+import PropTypes from 'prop-types';
 import reduce from 'lodash/reduce';
 import { Style } from 'radium';
 
@@ -27,28 +28,28 @@ const isMinimElement = element => isFunction(element.getMetaProperty);
 
 class Attributes extends React.Component {
   static propTypes = {
-    namedTypes: React.PropTypes.bool,
-    collapseByDefault: React.PropTypes.bool,
-    dataStructures: React.PropTypes.oneOfType([
-      React.PropTypes.object, // minim
-      React.PropTypes.array, // legacy refract array
+    namedTypes: PropTypes.bool,
+    collapseByDefault: PropTypes.bool,
+    dataStructures: PropTypes.oneOfType([
+      PropTypes.object, // minim
+      PropTypes.array, // legacy refract array
     ]),
-    element: React.PropTypes.object,
-    includedProperties: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.string,
+    element: PropTypes.object,
+    includedProperties: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string,
     ]),
-    inheritedProperties: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.string,
+    inheritedProperties: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string,
     ]),
-    maxInheritanceDepth: React.PropTypes.any,
-    onElementLinkClick: React.PropTypes.func,
-    title: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.string,
+    maxInheritanceDepth: PropTypes.any,
+    onElementLinkClick: PropTypes.func,
+    title: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string,
     ]),
-    theme: React.PropTypes.object,
+    theme: PropTypes.object,
   };
 
   static defaultProps = {
@@ -57,19 +58,19 @@ class Attributes extends React.Component {
   };
 
   static childContextTypes = {
-    dereferencedDataStructures: React.PropTypes.array,
-    theme: React.PropTypes.object,
-    element: React.PropTypes.object,
-    namedTypes: React.PropTypes.bool,
-    eventEmitter: React.PropTypes.object,
-    onElementLinkClick: React.PropTypes.func,
-    includedProperties: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.string,
+    dereferencedDataStructures: PropTypes.array,
+    theme: PropTypes.object,
+    element: PropTypes.object,
+    namedTypes: PropTypes.bool,
+    eventEmitter: PropTypes.object,
+    onElementLinkClick: PropTypes.func,
+    includedProperties: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string,
     ]),
-    inheritedProperties: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.string,
+    inheritedProperties: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string,
     ]),
   };
 

--- a/src/Components/Column/Column.js
+++ b/src/Components/Column/Column.js
@@ -1,14 +1,15 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 import merge from 'lodash/merge';
 
 @Radium
 class Column extends React.Component {
   static propTypes = {
-    style: React.PropTypes.object,
-    children: React.PropTypes.oneOfType([
-      React.PropTypes.object,
-      React.PropTypes.array,
+    style: PropTypes.object,
+    children: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.array,
     ]),
   };
 

--- a/src/Components/Description/Description.js
+++ b/src/Components/Description/Description.js
@@ -4,6 +4,7 @@ import marked from 'marked';
 import merge from 'lodash/merge';
 import Radium from 'radium';
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { DEFAULT_FONT_FAMILY } from '../../Constants/fonts';
 
@@ -14,12 +15,12 @@ marked.setOptions({
 @Radium
 class Description extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    style: React.PropTypes.object,
+    element: PropTypes.object,
+    style: PropTypes.object,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
+    theme: PropTypes.object,
   };
 
   static getDescription(element) {

--- a/src/Components/Error/Error.js
+++ b/src/Components/Error/Error.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 import merge from 'lodash/merge';
 
@@ -7,8 +8,8 @@ import { DEFAULT_FONT_FAMILY } from '../../Constants/fonts';
 @Radium
 class Error extends React.Component {
   static propTypes = {
-    errorMessage: React.PropTypes.string,
-    style: React.PropTypes.object,
+    errorMessage: PropTypes.string,
+    style: PropTypes.object,
   };
 
   get style() {

--- a/src/Components/InheritanceTree/InheritanceTree.js
+++ b/src/Components/InheritanceTree/InheritanceTree.js
@@ -2,6 +2,7 @@ import isEmpty from 'lodash/isEmpty';
 import merge from 'lodash/merge';
 import Radium from 'radium';
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import {
   findParent,
@@ -13,15 +14,15 @@ import { DEFAULT_FONT_FAMILY } from '../../Constants/fonts';
 @Radium
 class InheritanceTree extends React.Component {
   static propTypes = {
-    dataStructures: React.PropTypes.array,
-    dereferencedDataStructures: React.PropTypes.array,
-    element: React.PropTypes.object,
-    style: React.PropTypes.object,
+    dataStructures: PropTypes.array,
+    dereferencedDataStructures: PropTypes.array,
+    element: PropTypes.object,
+    style: PropTypes.object,
   };
 
   static contextTypes = {
-    onElementLinkClick: React.PropTypes.func,
-    theme: React.PropTypes.object,
+    onElementLinkClick: PropTypes.func,
+    theme: PropTypes.object,
   };
 
   static buildInheritanceTree = function ({ element, dereferencedDataStructures }) {

--- a/src/Components/Key/Key.js
+++ b/src/Components/Key/Key.js
@@ -2,6 +2,7 @@ import isUndefined from 'lodash/isUndefined';
 import merge from 'lodash/merge';
 import Radium from 'radium';
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { MONO_FONT_FAMILY } from '../../Constants/fonts';
 
@@ -12,14 +13,14 @@ import {
 @Radium
 class Key extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    index: React.PropTypes.number,
-    onClick: React.PropTypes.func,
-    style: React.PropTypes.object,
+    element: PropTypes.object,
+    index: PropTypes.number,
+    onClick: PropTypes.func,
+    style: PropTypes.object,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
+    theme: PropTypes.object,
   };
 
   get style() {

--- a/src/Components/Object/Object.js
+++ b/src/Components/Object/Object.js
@@ -1,6 +1,7 @@
 import merge from 'lodash/merge';
 import Radium from 'radium';
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import ObjectProperties from '../ObjectProperties/ObjectProperties';
 import ObjectHeader from '../ObjectHeader/ObjectHeader';
@@ -20,16 +21,16 @@ import {
 @Radium
 class ObjectComponent extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    expandableCollapsible: React.PropTypes.bool,
-    parentElement: React.PropTypes.object,
-    style: React.PropTypes.object,
-    collapseByDefault: React.PropTypes.bool,
-    isSample: React.PropTypes.bool,
+    element: PropTypes.object,
+    expandableCollapsible: PropTypes.bool,
+    parentElement: PropTypes.object,
+    style: PropTypes.object,
+    collapseByDefault: PropTypes.bool,
+    isSample: PropTypes.bool,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
+    theme: PropTypes.object,
   };
 
   constructor(props) {

--- a/src/Components/ObjectDefaults/ObjectDefaults.js
+++ b/src/Components/ObjectDefaults/ObjectDefaults.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 import merge from 'lodash/merge';
 
@@ -15,14 +16,14 @@ import {
 @Radium
 class ObjectDefaults extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    parentElement: React.PropTypes.object,
-    style: React.PropTypes.object,
-    collapseByDefault: React.PropTypes.bool,
+    element: PropTypes.object,
+    parentElement: PropTypes.object,
+    style: PropTypes.object,
+    collapseByDefault: PropTypes.bool,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
+    theme: PropTypes.object,
   };
 
   constructor(props) {

--- a/src/Components/ObjectHeader/ObjectHeader.js
+++ b/src/Components/ObjectHeader/ObjectHeader.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 import merge from 'lodash/merge';
 
@@ -17,18 +18,18 @@ import {
 @Radium
 class ObjectHeader extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    expandableCollapsible: React.PropTypes.bool,
-    isExpanded: React.PropTypes.bool,
-    onSampleToggleClick: React.PropTypes.func,
-    onToggleClick: React.PropTypes.func,
-    onTypeClick: React.PropTypes.func,
-    parentElement: React.PropTypes.object,
-    style: React.PropTypes.object,
+    element: PropTypes.object,
+    expandableCollapsible: PropTypes.bool,
+    isExpanded: PropTypes.bool,
+    onSampleToggleClick: PropTypes.func,
+    onToggleClick: PropTypes.func,
+    onTypeClick: PropTypes.func,
+    parentElement: PropTypes.object,
+    style: PropTypes.object,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
+    theme: PropTypes.object,
   };
 
   get style() {

--- a/src/Components/ObjectProperties/ObjectProperties.js
+++ b/src/Components/ObjectProperties/ObjectProperties.js
@@ -5,6 +5,7 @@ import last from 'lodash/last';
 import map from 'lodash/map';
 import max from 'lodash/max';
 import React from 'react';
+import PropTypes from 'prop-types';
 import values from 'lodash/values';
 import Radium from 'radium';
 import merge from 'lodash/merge';
@@ -24,23 +25,23 @@ import {
 @Radium
 class ObjectProperties extends React.Component {
   static propTypes = {
-    collapseByDefault: React.PropTypes.bool,
-    element: React.PropTypes.object,
-    keyWidth: React.PropTypes.number,
-    reportKeyWidth: React.PropTypes.func,
-    style: React.PropTypes.object,
+    collapseByDefault: PropTypes.bool,
+    element: PropTypes.object,
+    keyWidth: PropTypes.number,
+    reportKeyWidth: PropTypes.func,
+    style: PropTypes.object,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
-    eventEmitter: React.PropTypes.object,
-    includedProperties: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.string,
+    theme: PropTypes.object,
+    eventEmitter: PropTypes.object,
+    includedProperties: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string,
     ]),
-    inheritedProperties: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.string,
+    inheritedProperties: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string,
     ]),
   };
 

--- a/src/Components/ObjectPropertiesGroup/ObjectPropertiesGroup.js
+++ b/src/Components/ObjectPropertiesGroup/ObjectPropertiesGroup.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import radium from 'radium';
 import merge from 'lodash/merge';
 
@@ -10,22 +11,22 @@ import { DEFAULT_FONT_FAMILY } from '../../Constants/fonts';
 
 class ObjectPropertiesGroup extends React.Component {
   static propTypes = {
-    children: React.PropTypes.any,
-    name: React.PropTypes.string,
-    style: React.PropTypes.object,
-    type: React.PropTypes.string,
+    children: PropTypes.any,
+    name: PropTypes.string,
+    style: PropTypes.object,
+    type: PropTypes.string,
   };
 
   static contextTypes = {
-    dereferencedDataStructures: React.PropTypes.array,
-    onElementLinkClick: React.PropTypes.func,
-    includedProperties: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.string,
+    dereferencedDataStructures: PropTypes.array,
+    onElementLinkClick: PropTypes.func,
+    includedProperties: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string,
     ]),
-    inheritedProperties: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.string,
+    inheritedProperties: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string,
     ]),
   };
 

--- a/src/Components/ObjectProperty/KeyColumn.js
+++ b/src/Components/ObjectProperty/KeyColumn.js
@@ -1,6 +1,7 @@
 import Radium from 'radium';
 import React from 'react';
-import reactDom from 'react-dom';
+import ReactDom from 'react-dom';
+import PropTypes from 'prop-types';
 import merge from 'lodash/merge';
 import random from 'lodash/random';
 import Column from '../Column/Column';
@@ -16,16 +17,16 @@ import {
 @Radium
 class KeyColumn extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    keyWidth: React.PropTypes.number,
-    onClick: React.PropTypes.func,
-    parentElement: React.PropTypes.object,
-    reportKeyWidth: React.PropTypes.func,
-    style: React.PropTypes.object,
+    element: PropTypes.object,
+    keyWidth: PropTypes.number,
+    onClick: PropTypes.func,
+    parentElement: PropTypes.object,
+    reportKeyWidth: PropTypes.func,
+    style: PropTypes.object,
   };
 
   static contextTypes = {
-    eventEmitter: React.PropTypes.object,
+    eventEmitter: PropTypes.object,
   };
 
   componentDidMount = () => {
@@ -59,7 +60,7 @@ class KeyColumn extends React.Component {
       keyIdentifier = random(0, 1000000);
     }
 
-    const keyDomNode = reactDom.findDOMNode(this.refs.key);
+    const keyDomNode = ReactDom.findDOMNode(this.refs.key);
 
     if (keyDomNode) {
       this.props.reportKeyWidth(keyIdentifier, keyDomNode.clientWidth);

--- a/src/Components/ObjectProperty/ObjectProperty.js
+++ b/src/Components/ObjectProperty/ObjectProperty.js
@@ -1,6 +1,7 @@
 import merge from 'lodash/merge';
 import Radium from 'radium';
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Column from '../Column/Column';
 import Description from '../Description/Description';
@@ -26,27 +27,27 @@ import {
 @Radium
 class ObjectProperty extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    index: React.PropTypes.number,
-    parentElement: React.PropTypes.object,
-    reportKeyWidth: React.PropTypes.func,
-    style: React.PropTypes.object,
-    keyWidth: React.PropTypes.number,
-    collapseByDefault: React.PropTypes.bool,
+    element: PropTypes.object,
+    index: PropTypes.number,
+    parentElement: PropTypes.object,
+    reportKeyWidth: PropTypes.func,
+    style: PropTypes.object,
+    keyWidth: PropTypes.number,
+    collapseByDefault: PropTypes.bool,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
-    eventEmitter: React.PropTypes.object,
-    showMemberParentLinks: React.PropTypes.bool,
-    onElementLinkClick: React.PropTypes.func,
-    includedProperties: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.string,
+    theme: PropTypes.object,
+    eventEmitter: PropTypes.object,
+    showMemberParentLinks: PropTypes.bool,
+    onElementLinkClick: PropTypes.func,
+    includedProperties: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string,
     ]),
-    inheritedProperties: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.string,
+    inheritedProperties: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string,
     ]),
   };
 

--- a/src/Components/ObjectProperty/StructuredObjectProperty.js
+++ b/src/Components/ObjectProperty/StructuredObjectProperty.js
@@ -1,6 +1,7 @@
 import merge from 'lodash/merge';
 import Radium from 'radium';
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Column from '../Column/Column';
 import Description from '../Description/Description';
@@ -25,28 +26,28 @@ import {
 @Radium
 class StructuredObjectProperty extends React.Component {
   static propTypes = {
-    collapseByDefault: React.PropTypes.bool,
-    element: React.PropTypes.object,
-    index: React.PropTypes.number,
-    keyWidth: React.PropTypes.number,
-    parentElement: React.PropTypes.object,
-    reportKeyWidth: React.PropTypes.func,
-    style: React.PropTypes.object,
+    collapseByDefault: PropTypes.bool,
+    element: PropTypes.object,
+    index: PropTypes.number,
+    keyWidth: PropTypes.number,
+    parentElement: PropTypes.object,
+    reportKeyWidth: PropTypes.func,
+    style: PropTypes.object,
   };
 
   static contextTypes = {
-    element: React.PropTypes.object,
-    theme: React.PropTypes.object,
-    showMemberParentLinks: React.PropTypes.bool,
-    namedTypes: React.PropTypes.bool,
-    onElementLinkClick: React.PropTypes.func,
-    includedProperties: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.string,
+    element: PropTypes.object,
+    theme: PropTypes.object,
+    showMemberParentLinks: PropTypes.bool,
+    namedTypes: PropTypes.bool,
+    onElementLinkClick: PropTypes.func,
+    includedProperties: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string,
     ]),
-    inheritedProperties: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.string,
+    inheritedProperties: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string,
     ]),
   };
 

--- a/src/Components/ObjectProperty/ToggleColumn.js
+++ b/src/Components/ObjectProperty/ToggleColumn.js
@@ -1,23 +1,24 @@
 import Radium from 'radium';
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Toggle from '../Toggle/Toggle';
 
 @Radium
 class ToggleColumn extends React.Component {
   static propTypes = {
-    isExpanded: React.PropTypes.bool,
-    onClick: React.PropTypes.func,
+    isExpanded: PropTypes.bool,
+    onClick: PropTypes.func,
   };
 
   static contextTypes = {
-    includedProperties: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.string,
+    includedProperties: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string,
     ]),
-    inheritedProperties: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.string,
+    inheritedProperties: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string,
     ]),
   };
 

--- a/src/Components/ObjectProperty/TypeColumn.js
+++ b/src/Components/ObjectProperty/TypeColumn.js
@@ -1,5 +1,6 @@
 import Radium from 'radium';
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Column from '../Column/Column';
 import Type from '../Type/Type';
@@ -11,11 +12,11 @@ import {
 @Radium
 class TypeColumn extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
+    element: PropTypes.object,
   };
 
   static contextTypes = {
-    namedTypes: React.PropTypes.bool,
+    namedTypes: PropTypes.bool,
   };
 
   constructor(props) {

--- a/src/Components/ObjectPropertyDefaults/ObjectPropertyDefaults.js
+++ b/src/Components/ObjectPropertyDefaults/ObjectPropertyDefaults.js
@@ -1,11 +1,12 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Column from '../Column/Column';
 import Sample from '../Sample/Sample';
 
 class ObjectPropertySamples extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    collapseByDefault: React.PropTypes.bool,
+    element: PropTypes.object,
+    collapseByDefault: PropTypes.bool,
   };
 
   get style() {

--- a/src/Components/ObjectPropertySamples/ObjectPropertySamples.js
+++ b/src/Components/ObjectPropertySamples/ObjectPropertySamples.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Column from '../Column/Column';
 import Row from '../Row/Row';
@@ -13,8 +14,8 @@ import {
 
 class ObjectPropertySamples extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    collapseByDefault: React.PropTypes.bool,
+    element: PropTypes.object,
+    collapseByDefault: PropTypes.bool,
   };
 
   renderStyles() {

--- a/src/Components/ObjectSample/ObjectSample.js
+++ b/src/Components/ObjectSample/ObjectSample.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 import merge from 'lodash/merge';
 
@@ -10,16 +11,16 @@ import SampleToggle from '../SampleToggle/SampleToggle';
 @Radium
 class ObjectSample extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    sample: React.PropTypes.object,
-    sampleIndex: React.PropTypes.number,
-    samples: React.PropTypes.array,
-    style: React.PropTypes.object,
-    collapseByDefault: React.PropTypes.bool,
+    element: PropTypes.object,
+    sample: PropTypes.object,
+    sampleIndex: PropTypes.number,
+    samples: PropTypes.array,
+    style: PropTypes.object,
+    collapseByDefault: PropTypes.bool,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
+    theme: PropTypes.object,
   };
 
   constructor(props) {

--- a/src/Components/ObjectSamples/ObjectSamples.js
+++ b/src/Components/ObjectSamples/ObjectSamples.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 import merge from 'lodash/merge';
 
@@ -13,9 +14,9 @@ import {
 @Radium
 class ObjectSamples extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    style: React.PropTypes.object,
-    collapseByDefault: React.PropTypes.bool,
+    element: PropTypes.object,
+    style: PropTypes.object,
+    collapseByDefault: PropTypes.bool,
   };
 
   get style() {

--- a/src/Components/ParentInfo/ParentInfoLink.js
+++ b/src/Components/ParentInfo/ParentInfoLink.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import radium from 'radium';
 import merge from 'lodash/merge';
 
@@ -11,13 +12,13 @@ import { DEFAULT_FONT_FAMILY } from '../../Constants/fonts';
 
 class ParentInfoLink extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    style: React.PropTypes.object,
+    element: PropTypes.object,
+    style: PropTypes.object,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
-    onElementLinkClick: React.PropTypes.func,
+    theme: PropTypes.object,
+    onElementLinkClick: PropTypes.func,
   };
 
   get style() {

--- a/src/Components/Primitive/Primitive.js
+++ b/src/Components/Primitive/Primitive.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import merge from 'lodash/merge';
 
 import Row from '../Row/Row';
@@ -14,13 +15,13 @@ import {
 
 class Primitive extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    style: React.PropTypes.object,
-    collapseByDefault: React.PropTypes.bool,
+    element: PropTypes.object,
+    style: PropTypes.object,
+    collapseByDefault: PropTypes.bool,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
+    theme: PropTypes.object,
   };
 
   get style() {

--- a/src/Components/PrimitiveValue/PrimitiveValue.js
+++ b/src/Components/PrimitiveValue/PrimitiveValue.js
@@ -1,6 +1,7 @@
 import isUndefined from 'lodash/isUndefined';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import merge from 'lodash/merge';
 import Radium from 'radium';
 
@@ -14,17 +15,17 @@ import { DEFAULT_FONT_FAMILY } from '../../Constants/fonts';
 @Radium
 class PrimitiveValue extends React.Component {
   static propTypes = {
-    value: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.number,
-      React.PropTypes.bool,
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.bool,
     ]),
-    element: React.PropTypes.object,
-    style: React.PropTypes.object,
+    element: PropTypes.object,
+    style: PropTypes.object,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
+    theme: PropTypes.object,
   };
 
   get style() {

--- a/src/Components/Requirement/Requirement.js
+++ b/src/Components/Requirement/Requirement.js
@@ -1,11 +1,12 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import radium from 'radium';
 
 import { DEFAULT_FONT_FAMILY } from '../../Constants/fonts';
 
 class Requirement extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
+    element: PropTypes.object,
   };
 
   get requirement() {

--- a/src/Components/Row/Row.js
+++ b/src/Components/Row/Row.js
@@ -1,12 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import merge from 'lodash/merge';
 
 
 class Row extends React.Component {
   static propTypes = {
-    onClick: React.PropTypes.func,
-    style: React.PropTypes.object,
-    children: React.PropTypes.any,
+    onClick: PropTypes.func,
+    style: PropTypes.object,
+    children: PropTypes.any,
   };
 
   getStyles() {

--- a/src/Components/Ruler/Ruler.js
+++ b/src/Components/Ruler/Ruler.js
@@ -1,19 +1,20 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import radium from 'radium';
 import merge from 'lodash/merge';
 
 class Ruler extends React.Component {
   static propTypes = {
-    children: React.PropTypes.oneOfType([
-      React.PropTypes.object,
-      React.PropTypes.array,
+    children: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.array,
     ]),
-    style: React.PropTypes.object,
-    subtle: React.PropTypes.bool,
+    style: PropTypes.object,
+    subtle: PropTypes.bool,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
+    theme: PropTypes.object,
   };
 
   get style() {

--- a/src/Components/Sample/Sample.js
+++ b/src/Components/Sample/Sample.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 import merge from 'lodash/merge';
 
@@ -10,11 +11,11 @@ import SampleToggle from '../SampleToggle/SampleToggle';
 @Radium
 class Sample extends React.Component {
   static propTypes = {
-    style: React.PropTypes.object,
-    element: React.PropTypes.object,
-    sample: React.PropTypes.object,
-    title: React.PropTypes.string,
-    collapseByDefault: React.PropTypes.bool,
+    style: PropTypes.object,
+    element: PropTypes.object,
+    sample: PropTypes.object,
+    title: PropTypes.string,
+    collapseByDefault: PropTypes.bool,
   };
 
   constructor(props) {

--- a/src/Components/SampleToggle/SampleToggle.js
+++ b/src/Components/SampleToggle/SampleToggle.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 import merge from 'lodash/merge';
 
@@ -10,15 +11,15 @@ import { DEFAULT_FONT_FAMILY } from '../../Constants/fonts';
 @Radium
 class SampleToggle extends React.Component {
   static propTypes = {
-    onClick: React.PropTypes.func,
-    sampleName: React.PropTypes.string,
-    isExpanded: React.PropTypes.bool,
-    style: React.PropTypes.object,
-    sampleTitle: React.PropTypes.string,
+    onClick: PropTypes.func,
+    sampleName: PropTypes.string,
+    isExpanded: PropTypes.bool,
+    style: PropTypes.object,
+    sampleTitle: PropTypes.string,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
+    theme: PropTypes.object,
   };
 
   renderStyles() {

--- a/src/Components/Select/Select.js
+++ b/src/Components/Select/Select.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 import merge from 'lodash/merge';
 import isEmpty from 'lodash/isEmpty';
@@ -11,15 +12,15 @@ import SelectOption from '../SelectOption/SelectOption';
 @Radium
 class Select extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    parentElement: React.PropTypes.object,
-    keyWidth: React.PropTypes.number,
-    reportKeyWidth: React.PropTypes.func,
+    element: PropTypes.object,
+    parentElement: PropTypes.object,
+    keyWidth: PropTypes.number,
+    reportKeyWidth: PropTypes.func,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
-    eventEmitter: React.PropTypes.object,
+    theme: PropTypes.object,
+    eventEmitter: PropTypes.object,
   };
 
   constructor(props) {

--- a/src/Components/SelectOption/SelectOption.js
+++ b/src/Components/SelectOption/SelectOption.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 import merge from 'lodash/merge';
 
@@ -9,20 +10,20 @@ import { MONO_FONT_FAMILY } from '../../Constants/fonts';
 @Radium
 class SelectOption extends React.Component {
   static propTypes = {
-    children: React.PropTypes.oneOfType([
-      React.PropTypes.object,
-      React.PropTypes.array,
+    children: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.array,
     ]),
-    index: React.PropTypes.number,
-    element: React.PropTypes.object,
-    parentElement: React.PropTypes.object,
-    style: React.PropTypes.object,
-    keyWidth: React.PropTypes.number,
-    reportKeyWidth: React.PropTypes.func,
+    index: PropTypes.number,
+    element: PropTypes.object,
+    parentElement: PropTypes.object,
+    style: PropTypes.object,
+    keyWidth: PropTypes.number,
+    reportKeyWidth: PropTypes.func,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
+    theme: PropTypes.object,
   };
 
   get style() {

--- a/src/Components/Title/Title.js
+++ b/src/Components/Title/Title.js
@@ -2,18 +2,19 @@ import isEmpty from 'lodash/isEmpty';
 import merge from 'lodash/merge';
 import Radium from 'radium';
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { DEFAULT_FONT_FAMILY } from '../../Constants/fonts';
 
 @Radium
 class Title extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    style: React.PropTypes.object,
+    element: PropTypes.object,
+    style: PropTypes.object,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
+    theme: PropTypes.object,
   };
 
   get style() {

--- a/src/Components/Toggle/Toggle.js
+++ b/src/Components/Toggle/Toggle.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 
 import merge from 'lodash/merge';
@@ -6,9 +7,9 @@ import merge from 'lodash/merge';
 @Radium
 class Toggle extends React.Component {
   static propTypes = {
-    isExpanded: React.PropTypes.bool,
-    onClick: React.PropTypes.func,
-    style: React.PropTypes.object,
+    isExpanded: PropTypes.bool,
+    onClick: PropTypes.func,
+    style: PropTypes.object,
   };
 
   get style() {

--- a/src/Components/Type/Type.js
+++ b/src/Components/Type/Type.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import radium from 'radium';
 import merge from 'lodash/merge';
 
@@ -12,17 +13,17 @@ import { MONO_FONT_FAMILY } from '../../Constants/fonts';
 
 class Type extends React.Component {
   static propTypes = {
-    type: React.PropTypes.string,
-    reference: React.PropTypes.string,
-    element: React.PropTypes.object,
-    onClick: React.PropTypes.func,
-    style: React.PropTypes.object,
+    type: PropTypes.string,
+    reference: PropTypes.string,
+    element: PropTypes.object,
+    onClick: PropTypes.func,
+    style: PropTypes.object,
   };
 
   static contextTypes = {
-    theme: React.PropTypes.object,
-    onElementLinkClick: React.PropTypes.func,
-    dereferencedDataStructures: React.PropTypes.array,
+    theme: PropTypes.object,
+    onElementLinkClick: PropTypes.func,
+    dereferencedDataStructures: PropTypes.array,
   };
 
   get style() {

--- a/src/Components/Value/Value.js
+++ b/src/Components/Value/Value.js
@@ -1,6 +1,7 @@
 import isUndefined from 'lodash/isUndefined';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import {
   isArray,
@@ -16,12 +17,12 @@ import Attribute from '../Attribute/Attribute';
 
 class Value extends React.Component {
   static propTypes = {
-    element: React.PropTypes.object,
-    parentElement: React.PropTypes.object,
-    style: React.PropTypes.object,
-    expandableCollapsible: React.PropTypes.bool,
-    isSample: React.PropTypes.bool,
-    collapseByDefault: React.PropTypes.bool,
+    element: PropTypes.object,
+    parentElement: PropTypes.object,
+    style: PropTypes.object,
+    expandableCollapsible: PropTypes.bool,
+    isSample: PropTypes.bool,
+    collapseByDefault: PropTypes.bool,
   };
 
   render() {

--- a/webpack/clientNoReact.js
+++ b/webpack/clientNoReact.js
@@ -20,6 +20,12 @@ export default merge({}, clientWebpackConfig, {
       commonjs: 'react-dom',
       amd: 'react-dom'
     },
+    'prop-types': {
+      root: 'prop-types',
+      commonjs2: 'prop-types',
+      commonjs: 'prop-types',
+      amd: 'prop-types'
+    },
   },
 
   devtool: 'source-map',


### PR DESCRIPTION
The React.PropTypes were deprecated and removed from React 16.x