### PR TITLE
feat: minify production js

### DIFF
--- a/webpack/playground.js
+++ b/webpack/playground.js
@@ -2,6 +2,7 @@ import merge from 'lodash/merge';
 import path from 'path';
 import webpack from 'webpack';
 import baseConfig from './base';
+import UglifyJsPlugin from 'webpack/lib/optimize/UglifyJsPlugin';
 
 const isProduction = process.env.NODE_ENV === 'production';
 
@@ -29,6 +30,8 @@ export default merge({}, baseConfig, {
     let pluginsArray = [];
     if (!isProduction) {
       pluginsArray.push(new webpack.HotModuleReplacementPlugin());
+    } else {
+      pluginsArray.push(new UglifyJsPlugin());
     }
 
     return pluginsArray;


### PR DESCRIPTION
This makes sure we are not distributing any examples in the
jsdoc documentation which is licenced under CC0 in the case of
the `lodash` libs.

Applies the production https://attributes-kit.herokuapp.com/ app
running the `playground/server` started as:
```
NODE_ENV=production npm run start
```