### PR TITLE
test: normalize test strings before comparison

### DIFF
--- a/test/fixturesComparision.js
+++ b/test/fixturesComparision.js
@@ -7,6 +7,7 @@ import path from 'path';
 import assert from 'assert';
 import minim from 'minim';
 import minimParseResult from 'minim-parse-result';
+import pipe from 'lodash/fp/pipe';
 
 import parseMson from '../playground/parseMson';
 import { Attributes } from '../dist/attributes-kit-server';
@@ -30,11 +31,16 @@ describe('Comparision with reference fixtures', () => {
     /style\=\"([^\"]+)\"/g,
     (m, s) => `style="\n${s.split(';').sort().filter(s => s.length).join('\n')}\n"`);
 
-  const jsBeutifyOptions = {
+  const jsBeautifyOptions = {
     indent_size: 0,
     eol: '',
     preserve_newlines: false,
   };
+  const fpJsBeautify = options => data => jsBeautify.html(data, options);
+  const formatCanonical = pipe(
+    fpJsBeautify(jsBeautifyOptions),
+    formatStyle
+  );
 
   msonZoo.samples.forEach((sample) => {
     let renderedElement = null;
@@ -71,10 +77,7 @@ describe('Comparision with reference fixtures', () => {
         );
 
         it('They should be equal', () => {
-          const normalizedHtmlString = jsBeautify.html(htmlString, jsBeutifyOptions);
-          const normalizedReference = jsBeautify.html(reference, jsBeutifyOptions);
-
-          assert.equal(formatStyle(normalizedHtmlString), formatStyle(normalizedReference));
+          assert.equal(formatCanonical(htmlString), formatCanonical(reference));
         });
       });
     });

--- a/test/fixturesComparision.js
+++ b/test/fixturesComparision.js
@@ -12,7 +12,6 @@ import parseMson from '../playground/parseMson';
 import { Attributes } from '../dist/attributes-kit-server';
 
 describe('Comparision with reference fixtures', () => {
-
   /**
    *  Formats the style CSS attribute properties and sorts them for stable comparison
    *
@@ -31,6 +30,11 @@ describe('Comparision with reference fixtures', () => {
     /style\=\"([^\"]+)\"/g,
     (m, s) => `style="\n${s.split(';').sort().filter(s => s.length).join('\n')}\n"`);
 
+  const jsBeutifyOptions = {
+    indent_size: 0,
+    eol: '',
+    preserve_newlines: false,
+  };
 
   msonZoo.samples.forEach((sample) => {
     let renderedElement = null;
@@ -57,7 +61,7 @@ describe('Comparision with reference fixtures', () => {
           inheritedProperties: 'show',
         });
 
-        htmlString = jsBeautify.html(ReactDomServer.renderToStaticMarkup(renderedElement));
+        htmlString = ReactDomServer.renderToStaticMarkup(renderedElement);
       });
 
       describe('And I compare that with the reference fixture', () => {
@@ -67,7 +71,10 @@ describe('Comparision with reference fixtures', () => {
         );
 
         it('They should be equal', () => {
-          assert.equal(formatStyle(htmlString), formatStyle(reference));
+          const normalizedHtmlString = jsBeautify.html(htmlString, jsBeutifyOptions);
+          const normalizedReference = jsBeautify.html(reference, jsBeutifyOptions);
+
+          assert.equal(formatStyle(normalizedHtmlString), formatStyle(normalizedReference));
         });
       });
     });


### PR DESCRIPTION
Due to a difference of rendering on MacOS and Linux based environments, we need to normalize compared HTML files first. This commit removes indentation from files to prevent inequalities in tested files.