### PR TITLE
fix(package): make prop-types a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "mocha": "^3.2.0",
     "mson-zoo": "3.0.0-beta.1",
     "node-noop": "1.0.0",
+    "prop-types": "15.6.2",
     "radium": "0.24.1",
     "react": "15.4.2",
     "react-ace": "6.1.4",
@@ -160,8 +161,5 @@
   },
   "release": {
     "verifyConditions": "condition-circle"
-  },
-  "dependencies": {
-    "prop-types": "15.6.2"
   }
 }


### PR DESCRIPTION
The `transform-react-remove-prop-types` is used to remove them for the release bundles.